### PR TITLE
feat: Add Google AdSense script to website

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -19,6 +19,7 @@
 
     {{ partial "site-style.html" . }}
     {{ partial "site-scripts.html" . }}
+    {{ partial "ads.html" . }}
 
     {{ block "favicon" . }}
       {{ partialCached "site-favicon.html" . }}

--- a/layouts/partials/ads.html
+++ b/layouts/partials/ads.html
@@ -1,0 +1,5 @@
+<script
+    async
+    src="https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js?client=ca-pub-9060440160120562"
+    crossorigin="anonymous"
+></script>


### PR DESCRIPTION
Adds a new partial template `ads.html` that includes the Google AdSense
script. This will enable displaying ads on the website to generate
revenue.