### PR TITLE
feat(privacy-policy): Remove duplicate omit_header_text

### DIFF
--- a/content/privacy-policy/_index.md
+++ b/content/privacy-policy/_index.md
@@ -4,7 +4,7 @@ description: "How we handle your data."
 omit_header_text: true
 url: "/privacy-policy"
 draft: false
-#omit_header_text: true
+omit_header_text: true
 type: page
 menu:
   footer:


### PR DESCRIPTION
property

Removes the duplicate `omit_header_text` property from the
`content/privacy-policy/_index.md` file. This change ensures that
the file has a single, consistent value for the `omit_header_text`
property.