### PR TITLE
feat: implement Editorial Classic redesign

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1,0 +1,1496 @@
+/* =========================================================
+   LUCAS AGUIAR — EDITORIAL REDESIGN
+   Design tokens via CSS custom properties.
+   ========================================================= */
+
+/* ── Palette ── */
+:root {
+  --navy:       #0A1F44;
+  --blue-med:   #1E4A8A;
+  --blue-light: #4A90D9;
+  --gelo:       #E8F0F8;
+  --gold:       #C4922A;
+  --bordeaux:   #6B0F1A;
+  --creme:      #F5F0E8;
+
+  /* Semantic tokens — light (default) */
+  --bg:          var(--gelo);
+  --bg-elevated: #ffffff;
+  --bg-sunken:   #DDE7F2;
+  --fg:          var(--navy);
+  --fg-muted:    #4A5A76;
+  --fg-faint:    #7A8BA3;
+  --border:      #C9D6E5;
+  --accent:      var(--blue-med);
+  --accent-hover:var(--navy);
+  --accent-fg:   #ffffff;
+
+  /* Typography */
+  --font-serif: 'Fraunces', 'Source Serif Pro', Georgia, serif;
+  --font-sans:  'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', sans-serif;
+  --font-mono:  'JetBrains Mono', 'SF Mono', Menlo, monospace;
+
+  /* Spacing scale */
+  --space-1:  4px;
+  --space-2:  8px;
+  --space-3:  12px;
+  --space-4:  16px;
+  --space-5:  24px;
+  --space-6:  32px;
+  --space-7:  48px;
+  --space-8:  64px;
+  --space-9:  96px;
+  --space-10: 128px;
+}
+
+/* Dark theme */
+[data-theme="dark"] {
+  --bg:          #060B18;
+  --bg-elevated: #0C1428;
+  --bg-sunken:   #030811;
+  --fg:          #E8F0F8;
+  --fg-muted:    #9FB1CC;
+  --fg-faint:    #5A6B85;
+  --border:      #1A2744;
+  --accent:      var(--blue-light);
+  --accent-hover:#7DB5E8;
+  --accent-fg:   var(--navy);
+}
+
+/* ── Reset ── */
+*, *::before, *::after { box-sizing: border-box; margin: 0; padding: 0; }
+html { scroll-behavior: smooth; }
+body {
+  font-family: var(--font-sans);
+  background: var(--bg);
+  color: var(--fg);
+  line-height: 1.6;
+  -webkit-font-smoothing: antialiased;
+  text-rendering: optimizeLegibility;
+  transition: background-color 0.3s ease, color 0.3s ease;
+}
+img { max-width: 100%; display: block; }
+button { font: inherit; cursor: pointer; border: none; background: none; color: inherit; }
+a { color: inherit; text-decoration: none; }
+
+/* ── Utilities ── */
+.container        { max-width: 1280px; margin: 0 auto; padding: 0 var(--space-5); }
+.container-narrow { max-width: 720px;  margin: 0 auto; padding: 0 var(--space-5); }
+
+.mono-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
+:focus-visible { outline: 2px solid var(--accent); outline-offset: 3px; }
+
+/* ── Animations ── */
+@keyframes fadeUp {
+  from { opacity: 0; transform: translateY(12px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+.fade-up  { animation: fadeUp 0.6s ease both; }
+.delay-1  { animation-delay: 0.1s; }
+.delay-2  { animation-delay: 0.2s; }
+.delay-3  { animation-delay: 0.3s; }
+.delay-4  { animation-delay: 0.4s; }
+
+.reveal {
+  opacity: 0;
+  transform: translateY(16px);
+  transition: opacity 0.7s ease, transform 0.7s ease;
+}
+.reveal.in-view { opacity: 1; transform: translateY(0); }
+
+/* ── Scrollbar ── */
+::-webkit-scrollbar { width: 10px; }
+::-webkit-scrollbar-track { background: var(--bg); }
+::-webkit-scrollbar-thumb { background: var(--border); border-radius: 5px; }
+::-webkit-scrollbar-thumb:hover { background: var(--fg-faint); }
+
+/* =========================================================
+   NAVIGATION
+   ========================================================= */
+.nav-shell {
+  position: sticky;
+  top: 0;
+  z-index: 50;
+  background: color-mix(in oklab, var(--bg) 85%, transparent);
+  backdrop-filter: saturate(180%) blur(14px);
+  -webkit-backdrop-filter: saturate(180%) blur(14px);
+  border-bottom: 1px solid var(--border);
+}
+.nav-inner {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: var(--space-4) 0;
+}
+.nav-brand {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-family: var(--font-serif);
+  font-weight: 500;
+  font-size: 18px;
+  letter-spacing: -0.01em;
+}
+.nav-brand .monogram {
+  width: 32px; height: 32px;
+  display: grid;
+  place-items: center;
+  background: var(--fg);
+  color: var(--bg);
+  font-family: var(--font-serif);
+  font-style: italic;
+  font-weight: 500;
+  border-radius: 2px;
+  font-size: 15px;
+  flex-shrink: 0;
+}
+.nav-right {
+  display: flex;
+  align-items: center;
+  gap: var(--space-5);
+}
+.nav-links {
+  display: flex;
+  gap: var(--space-6);
+  font-size: 14px;
+  font-weight: 500;
+}
+.nav-links a {
+  color: var(--fg-muted);
+  position: relative;
+  padding: 4px 0;
+  transition: color 0.2s;
+}
+.nav-links a:hover { color: var(--fg); }
+.nav-links a.active { color: var(--fg); }
+.nav-links a.active::after {
+  content: '';
+  position: absolute;
+  left: 0; right: 0; bottom: -2px;
+  height: 1px;
+  background: var(--accent);
+}
+.nav-ctrls {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.theme-toggle {
+  width: 32px; height: 32px;
+  display: grid;
+  place-items: center;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  color: var(--fg-muted);
+  transition: all 0.15s;
+  flex-shrink: 0;
+}
+.theme-toggle:hover { border-color: var(--fg); color: var(--fg); }
+
+/* Mobile nav */
+.nav-menu-btn {
+  display: none;
+  width: 32px; height: 32px;
+  border: 1px solid var(--border);
+  border-radius: 2px;
+  align-items: center;
+  justify-content: center;
+  color: var(--fg-muted);
+}
+.nav-mobile {
+  display: none;
+  flex-direction: column;
+  padding: var(--space-4) 0;
+  border-top: 1px solid var(--border);
+  gap: var(--space-3);
+}
+.nav-mobile a {
+  font-size: 14px;
+  font-weight: 500;
+  color: var(--fg-muted);
+  padding: var(--space-2) 0;
+  transition: color 0.2s;
+}
+.nav-mobile a:hover { color: var(--fg); }
+.nav-mobile.open { display: flex; }
+
+@media (max-width: 700px) {
+  .nav-links   { display: none; }
+  .nav-menu-btn { display: flex; }
+}
+
+/* =========================================================
+   BUTTONS
+   ========================================================= */
+.btn {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-2);
+  padding: var(--space-3) var(--space-5);
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 2px;
+  transition: all 0.2s ease;
+  font-family: var(--font-sans);
+  letter-spacing: 0.01em;
+}
+.btn-primary {
+  background: var(--accent);
+  color: var(--accent-fg);
+}
+.btn-primary:hover {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+.btn-ghost {
+  border: 1px solid var(--border);
+  color: var(--fg);
+}
+.btn-ghost:hover {
+  border-color: var(--fg);
+  background: var(--bg-elevated);
+}
+.btn-link {
+  color: var(--accent);
+  padding: 0;
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+}
+.btn-link::after {
+  content: ' →';
+  display: inline;
+  transition: transform 0.2s;
+}
+.btn-link:hover { color: var(--accent-hover); }
+
+/* =========================================================
+   FOOTER
+   ========================================================= */
+.site-footer {
+  border-top: 1px solid var(--border);
+  padding: var(--space-8) 0 var(--space-6);
+  margin-top: var(--space-10);
+  font-size: 14px;
+}
+.footer-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr 1fr 1fr;
+  gap: var(--space-6);
+}
+.footer-col h4 {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  margin-bottom: var(--space-4);
+  font-weight: 500;
+}
+.footer-col a {
+  color: var(--fg-muted);
+  display: block;
+  padding: var(--space-1) 0;
+  transition: color 0.2s;
+}
+.footer-col a:hover { color: var(--accent); }
+.footer-brand-name {
+  font-family: var(--font-serif);
+  font-size: 22px;
+  margin-bottom: var(--space-2);
+}
+.footer-brand-desc {
+  color: var(--fg-muted);
+  max-width: 300px;
+  line-height: 1.5;
+  margin-bottom: var(--space-4);
+  font-size: 14px;
+}
+.footer-socials {
+  display: flex;
+  gap: var(--space-3);
+  color: var(--fg-muted);
+}
+.footer-socials a:hover { color: var(--accent); }
+.footer-bottom {
+  margin-top: var(--space-6);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: var(--fg-faint);
+  font-size: 12px;
+  font-family: var(--font-mono);
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+@media (max-width: 900px) {
+  .footer-grid { grid-template-columns: 1fr 1fr; }
+}
+@media (max-width: 600px) {
+  .footer-grid { grid-template-columns: 1fr; }
+  .footer-brand-desc { max-width: 100%; }
+}
+
+/* =========================================================
+   EDITORIAL HOME — VARIATION A
+   ========================================================= */
+
+/* Hero */
+.ed-hero {
+  padding: var(--space-9) 0 var(--space-8);
+  border-bottom: 1px solid var(--border);
+}
+.ed-hero-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  align-items: end;
+}
+.ed-hero-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  margin-bottom: var(--space-5);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.ed-hero-eyebrow::before {
+  content: '';
+  width: 32px;
+  height: 1px;
+  background: var(--accent);
+}
+.ed-hero h1 {
+  font-family: var(--font-serif);
+  font-weight: 300;
+  font-size: clamp(48px, 8vw, 104px);
+  line-height: 0.95;
+  letter-spacing: -0.035em;
+  color: var(--fg);
+}
+.ed-hero h1 em {
+  font-style: italic;
+  color: var(--accent);
+  font-weight: 400;
+}
+.ed-hero-aside {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  max-width: 420px;
+  border-left: 2px solid var(--accent);
+  padding-left: var(--space-5);
+}
+.ed-hero-aside .quote-mark {
+  font-size: 48px;
+  line-height: 0.5;
+  color: var(--accent);
+  font-style: italic;
+  display: block;
+  margin-bottom: var(--space-3);
+}
+.ed-hero-meta {
+  display: flex;
+  gap: var(--space-6);
+  margin-top: var(--space-6);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+.ed-hero-meta strong {
+  color: var(--fg);
+  font-weight: 500;
+  display: block;
+  margin-top: 4px;
+  letter-spacing: 0;
+  font-family: var(--font-sans);
+  text-transform: none;
+  font-size: 14px;
+}
+
+/* Featured post */
+.ed-featured {
+  padding: var(--space-8) 0;
+  border-bottom: 1px solid var(--border);
+}
+.ed-featured-label {
+  display: flex;
+  align-items: center;
+  gap: var(--space-4);
+  margin-bottom: var(--space-6);
+}
+.ed-featured-label hr {
+  flex: 1;
+  border: none;
+  border-top: 1px solid var(--border);
+}
+.ed-featured-grid {
+  display: grid;
+  grid-template-columns: 1.1fr 1fr;
+  gap: var(--space-8);
+  align-items: center;
+}
+.ed-featured-img {
+  aspect-ratio: 4/3;
+  background: var(--bg-sunken);
+  position: relative;
+  overflow: hidden;
+}
+.ed-featured-img img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+}
+.ed-featured-img .img-placeholder {
+  position: absolute; inset: 0;
+  display: grid; place-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  background: repeating-linear-gradient(135deg, var(--bg-sunken) 0, var(--bg-sunken) 8px, var(--bg-elevated) 8px, var(--bg-elevated) 16px);
+}
+.ed-featured-cat {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--space-4);
+}
+.ed-featured h2 {
+  font-family: var(--font-serif);
+  font-size: clamp(28px, 3.5vw, 48px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+  margin-bottom: var(--space-4);
+  color: var(--fg);
+  transition: color 0.2s;
+}
+.ed-featured h2:hover { color: var(--accent); cursor: pointer; }
+.ed-featured p {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-5);
+}
+.ed-byline {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  font-size: 13px;
+  color: var(--fg-faint);
+}
+.ed-byline .dot {
+  width: 3px; height: 3px;
+  border-radius: 50%;
+  background: var(--fg-faint);
+  display: inline-block;
+}
+
+/* Recent posts grid */
+.ed-grid {
+  padding: var(--space-8) 0;
+  border-bottom: 1px solid var(--border);
+}
+.ed-grid-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-7);
+}
+.ed-grid-head h2 {
+  font-family: var(--font-serif);
+  font-size: 32px;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+}
+.ed-grid-posts {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-7);
+}
+.ed-post {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-4);
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+.ed-post:hover { opacity: 0.7; }
+.ed-post-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--fg-faint);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border);
+}
+.ed-post-cat {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.ed-post h3 {
+  font-family: var(--font-serif);
+  font-size: 22px;
+  line-height: 1.2;
+  font-weight: 500;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+.ed-post p {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--fg-muted);
+}
+.ed-post-meta {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  margin-top: auto;
+  padding-top: var(--space-3);
+}
+
+/* Pull quote */
+.ed-pull {
+  padding: var(--space-9) 0;
+  border-bottom: 1px solid var(--border);
+  text-align: center;
+}
+.ed-pull blockquote {
+  font-family: var(--font-serif);
+  font-size: clamp(24px, 3.5vw, 40px);
+  line-height: 1.25;
+  letter-spacing: -0.015em;
+  font-weight: 300;
+  max-width: 900px;
+  margin: 0 auto;
+  font-style: italic;
+  color: var(--fg);
+}
+.ed-pull blockquote em { color: var(--accent); }
+.ed-pull cite {
+  display: block;
+  margin-top: var(--space-5);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  font-style: normal;
+}
+
+/* Work/consulting teaser */
+.ed-work {
+  padding: var(--space-8) 0;
+  border-bottom: 1px solid var(--border);
+}
+.ed-work-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: var(--space-6);
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--border);
+}
+.ed-work-head h2 {
+  font-family: var(--font-serif);
+  font-size: 32px;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+}
+.ed-work-grid {
+  display: grid;
+  grid-template-columns: repeat(4, 1fr);
+}
+.ed-work-item {
+  padding: var(--space-5) var(--space-4);
+  border-right: 1px solid var(--border);
+}
+.ed-work-item:last-child { border-right: none; }
+.ed-work-item:first-child { padding-left: 0; }
+.ed-work-item h3 {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  font-weight: 500;
+  margin-bottom: var(--space-3);
+  color: var(--fg);
+}
+.ed-work-item p {
+  font-size: 14px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+}
+.ed-work-item .num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  display: block;
+  margin-bottom: var(--space-3);
+}
+
+/* Newsletter / contact CTA */
+.ed-newsletter {
+  padding: var(--space-8) 0;
+}
+.ed-newsletter-inner {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  align-items: center;
+}
+.ed-newsletter h2 {
+  font-family: var(--font-serif);
+  font-size: clamp(28px, 3.5vw, 44px);
+  line-height: 1.05;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+  margin-bottom: var(--space-4);
+}
+.ed-newsletter p {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.55;
+  color: var(--fg-muted);
+}
+.ed-form {
+  display: flex;
+  gap: var(--space-2);
+  border-bottom: 1px solid var(--fg);
+  padding-bottom: var(--space-3);
+}
+.ed-form input {
+  flex: 1;
+  border: none;
+  background: transparent;
+  font-family: var(--font-serif);
+  font-size: 18px;
+  color: var(--fg);
+  outline: none;
+  padding: var(--space-2) 0;
+}
+.ed-form input::placeholder { color: var(--fg-faint); }
+.ed-form-note {
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
+/* Editorial home responsive */
+@media (max-width: 900px) {
+  .ed-hero-grid,
+  .ed-featured-grid,
+  .ed-newsletter-inner { grid-template-columns: 1fr; }
+  .ed-grid-posts { grid-template-columns: 1fr 1fr; }
+  .ed-work-grid  { grid-template-columns: 1fr 1fr; }
+  .ed-work-item  { border-right: none; border-bottom: 1px solid var(--border); padding-left: 0; }
+  .ed-work-item:last-child { border-bottom: none; }
+}
+@media (max-width: 600px) {
+  .ed-grid-posts { grid-template-columns: 1fr; }
+  .ed-work-grid  { grid-template-columns: 1fr; }
+}
+
+/* =========================================================
+   PAGE HEADER (shared across blog, about, contact, privacy)
+   ========================================================= */
+.page-head {
+  padding: var(--space-9) 0 var(--space-7);
+  border-bottom: 1px solid var(--border);
+}
+.page-head-grid {
+  display: grid;
+  grid-template-columns: 2fr 1fr;
+  gap: var(--space-6);
+  align-items: end;
+}
+.page-head-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.page-head-eyebrow::before {
+  content: '';
+  width: 24px; height: 1px;
+  background: var(--accent);
+}
+.page-head h1 {
+  font-family: var(--font-serif);
+  font-size: clamp(44px, 6vw, 88px);
+  line-height: 0.98;
+  letter-spacing: -0.03em;
+  font-weight: 300;
+}
+.page-head p {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+}
+@media (max-width: 700px) {
+  .page-head-grid { grid-template-columns: 1fr; }
+}
+
+/* =========================================================
+   BLOG LIST
+   ========================================================= */
+.blog-wrap { padding: var(--space-7) 0; }
+.blog-toolbar {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  padding: var(--space-4) 0;
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-5);
+  font-family: var(--font-mono);
+  font-size: 12px;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+.blog-toolbar .count {
+  color: var(--fg-faint);
+  letter-spacing: 0.08em;
+}
+.blog-toolbar .count strong { color: var(--fg); font-weight: 500; }
+.blog-tags {
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.blog-tag-btn {
+  padding: 5px 12px;
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-muted);
+  letter-spacing: 0.05em;
+  transition: all 0.15s;
+  cursor: pointer;
+  background: none;
+}
+.blog-tag-btn:hover { border-color: var(--fg); color: var(--fg); }
+.blog-tag-btn.active {
+  background: var(--fg);
+  color: var(--bg);
+  border-color: var(--fg);
+}
+.blog-list {
+  display: flex;
+  flex-direction: column;
+}
+.blog-entry {
+  display: grid;
+  grid-template-columns: 140px 1fr 100px;
+  gap: var(--space-6);
+  padding: var(--space-6) 0;
+  border-bottom: 1px solid var(--border);
+  align-items: start;
+  cursor: pointer;
+  transition: padding 0.3s;
+}
+.blog-entry:hover { padding-left: var(--space-3); }
+.blog-entry:hover .blog-entry-title { color: var(--accent); }
+.blog-entry-date {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--fg-faint);
+  padding-top: 6px;
+}
+.blog-entry-date .year {
+  display: block;
+  color: var(--fg);
+  font-size: 16px;
+  margin-top: 2px;
+}
+.blog-entry-cat {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--space-2);
+}
+.blog-entry-title {
+  font-family: var(--font-serif);
+  font-size: 26px;
+  line-height: 1.15;
+  letter-spacing: -0.015em;
+  font-weight: 500;
+  color: var(--fg);
+  margin-bottom: var(--space-3);
+  transition: color 0.2s;
+}
+.blog-entry-excerpt {
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.55;
+  color: var(--fg-muted);
+  max-width: 640px;
+}
+.blog-entry-meta {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--fg-faint);
+  text-align: right;
+  padding-top: 6px;
+  line-height: 1.8;
+}
+.blog-entry[data-hidden="true"] { display: none; }
+@media (max-width: 700px) {
+  .blog-entry { grid-template-columns: 1fr; gap: var(--space-3); }
+  .blog-entry-meta { text-align: left; }
+}
+
+/* =========================================================
+   SINGLE POST
+   ========================================================= */
+.post-wrap {
+  padding: var(--space-8) 0 var(--space-9);
+}
+.post-back {
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-muted);
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  margin-bottom: var(--space-6);
+  transition: color 0.15s;
+}
+.post-back:hover { color: var(--accent); }
+.post-header {
+  max-width: 780px;
+  margin: 0 auto var(--space-7);
+  text-align: center;
+}
+.post-header .cat {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin-bottom: var(--space-4);
+}
+.post-header h1 {
+  font-family: var(--font-serif);
+  font-size: clamp(32px, 5vw, 58px);
+  line-height: 1.05;
+  letter-spacing: -0.025em;
+  font-weight: 500;
+  margin-bottom: var(--space-5);
+}
+.post-header .lead {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  font-style: italic;
+}
+.post-meta {
+  max-width: 780px;
+  margin: 0 auto var(--space-7);
+  padding: var(--space-4) 0;
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+  flex-wrap: wrap;
+  gap: var(--space-3);
+}
+.post-meta .author {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  color: var(--fg);
+  text-transform: none;
+  letter-spacing: 0;
+  font-family: var(--font-sans);
+  font-size: 13px;
+}
+.post-meta .avatar {
+  width: 32px; height: 32px;
+  background: var(--bg-sunken);
+  border-radius: 50%;
+  overflow: hidden;
+}
+.post-cover {
+  max-width: 1000px;
+  margin: 0 auto var(--space-7);
+  aspect-ratio: 16/7;
+  background: var(--bg-sunken);
+  overflow: hidden;
+}
+.post-cover img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+}
+.post-body {
+  max-width: 680px;
+  margin: 0 auto;
+  font-family: var(--font-serif);
+  font-size: 20px;
+  line-height: 1.75;
+  color: var(--fg);
+}
+/* Drop cap */
+.post-body > p:first-of-type::first-letter {
+  font-family: var(--font-serif);
+  font-size: 72px;
+  float: left;
+  line-height: 0.88;
+  padding: 8px 10px 0 0;
+  font-weight: 400;
+  color: var(--accent);
+}
+.post-body p { margin-bottom: var(--space-5); }
+.post-body h2 {
+  font-family: var(--font-serif);
+  font-size: 30px;
+  letter-spacing: -0.02em;
+  margin: var(--space-7) 0 var(--space-4);
+  font-weight: 500;
+}
+.post-body h3 {
+  font-family: var(--font-serif);
+  font-size: 24px;
+  margin: var(--space-6) 0 var(--space-3);
+  font-weight: 500;
+}
+.post-body blockquote {
+  margin: var(--space-6) 0;
+  padding-left: var(--space-5);
+  border-left: 3px solid var(--accent);
+  font-style: italic;
+  color: var(--fg-muted);
+  font-size: 22px;
+}
+.post-body pre {
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  padding: var(--space-5);
+  overflow-x: auto;
+  font-family: var(--font-mono);
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--fg);
+  margin: var(--space-5) 0;
+  border-radius: 4px;
+}
+.post-body code {
+  font-family: var(--font-mono);
+  font-size: 0.85em;
+  background: var(--bg-sunken);
+  padding: 2px 6px;
+  border-radius: 3px;
+  color: var(--accent);
+}
+.post-body pre code { background: none; padding: 0; color: var(--fg); }
+.post-body a {
+  color: var(--accent);
+  border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+  transition: border-color 0.2s;
+}
+.post-body a:hover { border-bottom-color: var(--accent); }
+.post-body ul, .post-body ol {
+  padding-left: var(--space-6);
+  margin-bottom: var(--space-5);
+}
+.post-body li { margin-bottom: var(--space-2); }
+.post-body img {
+  max-width: 100%;
+  height: auto;
+  border-radius: 2px;
+  margin: var(--space-5) auto;
+}
+.post-tags {
+  max-width: 680px;
+  margin: var(--space-7) auto var(--space-5);
+  padding-top: var(--space-5);
+  border-top: 1px solid var(--border);
+  display: flex;
+  gap: var(--space-2);
+  flex-wrap: wrap;
+}
+.post-tag {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  padding: 4px 10px;
+  background: var(--bg-sunken);
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  color: var(--fg-muted);
+}
+.post-footer {
+  max-width: 680px;
+  margin: var(--space-8) auto 0;
+  padding-top: var(--space-6);
+  border-top: 1px solid var(--border);
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-faint);
+}
+.post-footer a:hover { color: var(--accent); }
+.post-extras {
+  max-width: 680px;
+  margin: var(--space-8) auto 0;
+}
+
+/* =========================================================
+   ABOUT PAGE
+   ========================================================= */
+.about-wrap { padding: var(--space-8) 0; }
+.about-grid {
+  display: grid;
+  grid-template-columns: 220px 1fr 280px;
+  gap: var(--space-7);
+  align-items: start;
+}
+.about-toc {
+  position: sticky;
+  top: 100px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.about-toc h4 {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border);
+}
+.about-toc nav a {
+  display: block;
+  padding: 6px 0 6px 10px;
+  color: var(--fg-muted);
+  border-left: 1px solid var(--border);
+  transition: all 0.15s;
+}
+.about-toc nav a:hover {
+  color: var(--fg);
+  padding-left: 14px;
+  border-left-color: var(--accent);
+}
+/* Hugo TOC styling */
+.about-toc #TableOfContents ul {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+.about-toc #TableOfContents li { margin: 0; }
+.about-toc #TableOfContents a {
+  display: block;
+  padding: 6px 0 6px 10px;
+  color: var(--fg-muted);
+  border-left: 1px solid var(--border);
+  transition: all 0.15s;
+  font-size: 12px;
+  font-family: var(--font-mono);
+}
+.about-toc #TableOfContents a:hover {
+  color: var(--fg);
+  padding-left: 14px;
+  border-left-color: var(--accent);
+}
+.about-toc #TableOfContents ul ul a { padding-left: 22px; font-size: 11px; }
+
+.about-content {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.7;
+  color: var(--fg);
+}
+.about-content h2 {
+  font-family: var(--font-serif);
+  font-size: 30px;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+  margin: var(--space-7) 0 var(--space-4);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border);
+}
+.about-content h2:first-child { margin-top: 0; }
+.about-content h3 {
+  font-family: var(--font-serif);
+  font-size: 22px;
+  font-weight: 500;
+  margin: var(--space-5) 0 var(--space-3);
+}
+.about-content p { margin-bottom: var(--space-4); color: var(--fg-muted); }
+.about-content a {
+  color: var(--accent);
+  border-bottom: 1px solid color-mix(in oklab, var(--accent) 40%, transparent);
+}
+.about-content a:hover { border-bottom-color: var(--accent); }
+.about-content ul {
+  list-style: none;
+  padding-left: 0;
+  margin-bottom: var(--space-5);
+}
+.about-content ul li {
+  padding: var(--space-3) 0 var(--space-3) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  position: relative;
+  font-size: 16px;
+  color: var(--fg-muted);
+}
+.about-content ul li::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 27px;
+  width: 8px; height: 1px;
+  background: var(--accent);
+}
+.about-content ul li strong {
+  color: var(--fg);
+  font-family: var(--font-sans);
+  font-weight: 600;
+  font-size: 14px;
+  display: block;
+  letter-spacing: 0.01em;
+}
+.about-side {
+  position: sticky;
+  top: 100px;
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-5);
+}
+.about-portrait {
+  aspect-ratio: 1;
+  background: var(--bg-sunken);
+  position: relative;
+  overflow: hidden;
+}
+.about-portrait::before {
+  content: '';
+  position: absolute;
+  top: -1px; left: -1px;
+  width: 30px; height: 30px;
+  border-top: 2px solid var(--accent);
+  border-left: 2px solid var(--accent);
+}
+.about-portrait img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+}
+.about-card {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: var(--space-5);
+}
+.about-card h4 {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+}
+.about-card .links {
+  display: flex;
+  flex-direction: column;
+  gap: var(--space-2);
+}
+.about-card .links a {
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+  padding: var(--space-2) 0;
+  font-size: 14px;
+  color: var(--fg-muted);
+  transition: color 0.15s;
+  border-bottom: 1px solid var(--border);
+}
+.about-card .links a:last-child { border-bottom: none; }
+.about-card .links a:hover { color: var(--accent); }
+.about-card .links a .glyph {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  color: var(--accent);
+  width: 20px;
+  flex-shrink: 0;
+}
+.about-bmc {
+  text-align: center;
+}
+@media (max-width: 1100px) {
+  .about-grid { grid-template-columns: 200px 1fr 240px; gap: var(--space-5); }
+}
+@media (max-width: 900px) {
+  .about-grid { grid-template-columns: 1fr; }
+  .about-toc, .about-side { position: static; }
+}
+
+/* =========================================================
+   CONTACT PAGE
+   ========================================================= */
+.contact-wrap { padding: var(--space-8) 0; }
+.contact-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  align-items: start;
+}
+.contact-intro h2 {
+  font-family: var(--font-serif);
+  font-size: 36px;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+  line-height: 1.1;
+  margin-bottom: var(--space-4);
+}
+.contact-intro p {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-6);
+}
+.contact-channels { display: flex; flex-direction: column; }
+.contact-channel {
+  display: grid;
+  grid-template-columns: 90px 1fr auto;
+  gap: var(--space-4);
+  padding: var(--space-5) 0;
+  border-bottom: 1px solid var(--border);
+  align-items: center;
+  transition: all 0.2s;
+}
+.contact-channel:hover { padding-left: var(--space-3); }
+.contact-channel .ch-label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+}
+.contact-channel .ch-value {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  color: var(--fg);
+}
+.contact-channel .ch-arr {
+  font-family: var(--font-mono);
+  color: var(--accent);
+}
+/* Form (redesigned but uses existing Formspree endpoint) */
+.contact-form-box {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: var(--space-6);
+}
+.contact-form-box h3 {
+  font-family: var(--font-serif);
+  font-size: 24px;
+  margin-bottom: var(--space-5);
+  letter-spacing: -0.01em;
+  font-weight: 500;
+}
+.form-row { margin-bottom: var(--space-4); }
+.form-row label {
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  margin-bottom: var(--space-2);
+}
+.form-row input,
+.form-row textarea,
+.form-row select {
+  width: 100%;
+  padding: 10px 0;
+  background: transparent;
+  border: none;
+  border-bottom: 1px solid var(--border);
+  font-family: var(--font-serif);
+  font-size: 17px;
+  color: var(--fg);
+  outline: none;
+  transition: border-color 0.2s;
+}
+.form-row input:focus,
+.form-row textarea:focus,
+.form-row select:focus { border-bottom-color: var(--accent); }
+.form-row textarea {
+  min-height: 120px;
+  resize: vertical;
+  font-family: var(--font-sans);
+  font-size: 15px;
+  line-height: 1.5;
+}
+.form-row select { cursor: pointer; }
+@media (max-width: 700px) {
+  .contact-grid { grid-template-columns: 1fr; }
+}
+
+/* =========================================================
+   PRIVACY PAGE
+   ========================================================= */
+.privacy-wrap { padding: var(--space-8) 0 var(--space-9); }
+.privacy-grid {
+  display: grid;
+  grid-template-columns: 240px 1fr;
+  gap: var(--space-7);
+  align-items: start;
+}
+.privacy-toc {
+  position: sticky;
+  top: 100px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+}
+.privacy-toc h4 {
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+  margin-bottom: var(--space-3);
+  padding-bottom: var(--space-2);
+  border-bottom: 1px solid var(--border);
+}
+.privacy-toc a {
+  display: block;
+  padding: 6px 0 6px 10px;
+  color: var(--fg-muted);
+  border-left: 1px solid var(--border);
+  transition: all 0.15s;
+}
+.privacy-toc a:hover {
+  color: var(--fg);
+  padding-left: 14px;
+  border-left-color: var(--accent);
+}
+.privacy-content {
+  font-family: var(--font-serif);
+  font-size: 17px;
+  line-height: 1.75;
+  color: var(--fg);
+  max-width: 680px;
+}
+.privacy-content h2 {
+  font-family: var(--font-serif);
+  font-size: 26px;
+  font-weight: 500;
+  margin: var(--space-7) 0 var(--space-3);
+  letter-spacing: -0.015em;
+  border-bottom: 1px solid var(--border);
+  padding-bottom: var(--space-2);
+}
+.privacy-content h2:first-child { margin-top: 0; }
+.privacy-content p { margin-bottom: var(--space-4); color: var(--fg-muted); }
+.privacy-content a { color: var(--accent); }
+.privacy-content ul { margin-left: var(--space-5); margin-bottom: var(--space-4); color: var(--fg-muted); }
+.privacy-content li { margin-bottom: var(--space-2); }
+.privacy-updated {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+  padding-bottom: var(--space-4);
+  border-bottom: 1px solid var(--border);
+  margin-bottom: var(--space-5);
+}
+@media (max-width: 700px) {
+  .privacy-grid { grid-template-columns: 1fr; }
+  .privacy-toc { position: static; }
+}
+
+/* =========================================================
+   BUY ME A COFFEE
+   ========================================================= */
+.bmc-wrap {
+  max-width: 680px;
+  margin: var(--space-7) auto;
+  padding: var(--space-6);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  text-align: center;
+}
+.bmc-wrap .bmc-label {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  margin-bottom: var(--space-4);
+}
+
+/* =========================================================
+   GENERIC PAGE (fallback)
+   ========================================================= */
+.generic-page {
+  max-width: 720px;
+  margin: var(--space-9) auto;
+  padding: 0 var(--space-5);
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.75;
+  color: var(--fg);
+}
+.generic-page h1 {
+  font-family: var(--font-serif);
+  font-size: clamp(36px, 5vw, 60px);
+  font-weight: 300;
+  letter-spacing: -0.025em;
+  margin-bottom: var(--space-6);
+  line-height: 1.0;
+}
+.generic-page h2 {
+  font-size: 26px;
+  font-weight: 500;
+  margin: var(--space-6) 0 var(--space-3);
+  letter-spacing: -0.01em;
+}
+.generic-page p { margin-bottom: var(--space-4); color: var(--fg-muted); }
+.generic-page a { color: var(--accent); }
+.generic-page ul { margin-left: var(--space-5); margin-bottom: var(--space-4); }
+.generic-page li { margin-bottom: var(--space-2); }

--- a/assets/js/tag-filter.js
+++ b/assets/js/tag-filter.js
@@ -1,0 +1,26 @@
+(function () {
+  var buttons = document.querySelectorAll('.blog-tag-btn');
+  var entries = document.querySelectorAll('.blog-entry');
+  var countEl = document.querySelector('.blog-count');
+  if (!buttons.length) return;
+
+  function filter(tag) {
+    var visible = 0;
+    entries.forEach(function (entry) {
+      var entryTag = entry.getAttribute('data-tag') || '';
+      var show = tag === 'all' || entryTag.toLowerCase() === tag.toLowerCase();
+      entry.setAttribute('data-hidden', show ? 'false' : 'true');
+      if (show) visible++;
+    });
+    if (countEl) countEl.textContent = visible;
+    buttons.forEach(function (btn) {
+      btn.classList.toggle('active', btn.getAttribute('data-filter') === tag);
+    });
+  }
+
+  buttons.forEach(function (btn) {
+    btn.addEventListener('click', function () {
+      filter(btn.getAttribute('data-filter') || 'all');
+    });
+  });
+})();

--- a/assets/js/theme-toggle.js
+++ b/assets/js/theme-toggle.js
@@ -1,0 +1,44 @@
+(function () {
+  var btn = document.getElementById('theme-toggle-btn');
+  if (!btn) return;
+
+  function getTheme() {
+    try { return localStorage.getItem('theme') || 'light'; } catch { return 'light'; }
+  }
+  function setTheme(t) {
+    document.documentElement.setAttribute('data-theme', t);
+    try { localStorage.setItem('theme', t); } catch {}
+    btn.setAttribute('aria-label', t === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
+    btn.innerHTML = t === 'dark' ? sunIcon() : moonIcon();
+  }
+  function moonIcon() {
+    return '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>';
+  }
+  function sunIcon() {
+    return '<svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><circle cx="12" cy="12" r="4"/><path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M6.34 17.66l-1.41 1.41M19.07 4.93l-1.41 1.41"/></svg>';
+  }
+
+  // Init icon on load
+  setTheme(getTheme());
+
+  btn.addEventListener('click', function () {
+    setTheme(getTheme() === 'dark' ? 'light' : 'dark');
+  });
+
+  // Mobile menu toggle
+  var menuBtn = document.getElementById('nav-menu-btn');
+  var mobileNav = document.getElementById('nav-mobile');
+  if (menuBtn && mobileNav) {
+    menuBtn.addEventListener('click', function () {
+      mobileNav.classList.toggle('open');
+    });
+  }
+
+  // Scroll reveal
+  var obs = new IntersectionObserver(function (entries) {
+    entries.forEach(function (e) {
+      if (e.isIntersecting) e.target.classList.add('in-view');
+    });
+  }, { threshold: 0.1 });
+  document.querySelectorAll('.reveal').forEach(function (el) { obs.observe(el); });
+})();

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -1,64 +1,72 @@
 <!DOCTYPE html>
-<html lang="{{ site.LanguageCode | default site.Language.Lang  }}" {{- with partialCached "func/GetLanguageDirection" "GetLanguageDirection" }} dir="{{ . }}" {{- end }}>
-  <head>
-    <meta charset="utf-8">
-    <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
-    {{/* NOTE: the Site's title, and if there is a page title, that is set too */}}
-    <title>{{ block "title" . }}{{ with .Params.Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
-    <meta name="viewport" content="width=device-width,minimum-scale=1">
-    <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
-    {{ hugo.Generator }}
-    {{/* NOTE: For Production make sure you add `HUGO_ENV="production"` before your build command */}}
-    {{ $production := eq (getenv "HUGO_ENV") "production" | or (eq site.Params.env "production") }}
-    {{ $public := not .Params.private }}
-    {{ if and $production $public }}
-      <meta name="robots" content="index, follow">
-    {{ else }}
-      <meta name="robots" content="noindex, nofollow">
-    {{ end }}
+<html lang="{{ site.LanguageCode | default site.Language.Lang }}" data-theme="light"{{- with partialCached "func/GetLanguageDirection" "GetLanguageDirection" }} dir="{{ . }}"{{- end }}>
+<head>
+  <meta charset="utf-8">
+  <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1">
+  <title>{{ block "title" . }}{{ with .Params.Title }}{{ . }} | {{ end }}{{ .Site.Title }}{{ end }}</title>
+  <meta name="viewport" content="width=device-width,minimum-scale=1">
+  <meta name="description" content="{{ with .Description }}{{ . }}{{ else }}{{if .IsPage}}{{ .Summary }}{{ else }}{{ with .Site.Params.description }}{{ . }}{{ end }}{{ end }}{{ end }}">
+  {{ hugo.Generator }}
 
-    {{ partial "site-style.html" . }}
-    {{ partial "site-scripts.html" . }}
-    {{ partial "ads.html" . }}
+  {{ $production := eq (getenv "HUGO_ENV") "production" | or (eq site.Params.env "production") }}
+  {{ $public := not .Params.private }}
+  {{ if and $production $public }}
+    <meta name="robots" content="index, follow">
+  {{ else }}
+    <meta name="robots" content="noindex, nofollow">
+  {{ end }}
 
-    {{ block "favicon" . }}
-      {{ partialCached "site-favicon.html" . }}
-    {{ end }}
+  {{/* Dark mode FOUC prevention — runs before first paint */}}
+  <script>(function(){try{var t=localStorage.getItem('theme');if(t)document.documentElement.setAttribute('data-theme',t);}catch(e){}})();</script>
 
-    {{ if .OutputFormats.Get "RSS" }}
-    {{ with .OutputFormats.Get "RSS" }}
-      <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
-      <link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
-      {{ end }}
-    {{ end }}
+  {{/* Google Fonts */}}
+  <link rel="preconnect" href="https://fonts.googleapis.com">
+  <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+  <link href="https://fonts.googleapis.com/css2?family=Fraunces:ital,opsz,wght@0,9..144,300;0,9..144,400;0,9..144,500;1,9..144,300;1,9..144,400&family=Inter:wght@400;500;600&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
 
-    {{ if .Params.canonicalUrl }}
-      <link rel="canonical" href="{{ .Params.canonicalUrl }}">
-    {{ else }}
-      <link rel="canonical" href="{{ .Permalink }}">
-    {{ end }}
+  {{ partial "site-style.html" . }}
+  {{ partial "ads.html" . }}
 
-    {{/* NOTE: These Hugo Internal Templates can be found starting at https://github.com/gohugoio/hugo/tree/master/tpl/tplimpl/embedded/templates */}}
-    {{- template "_internal/opengraph.html" . -}}
-    {{- template "_internal/schema.html" . -}}
-    {{- template "_internal/twitter_cards.html" . -}}
+  {{ block "favicon" . }}{{ partialCached "site-favicon.html" . }}{{ end }}
 
-    {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production")  }}
-      {{ template "_internal/google_analytics.html" . }}
-    {{ end }}
-	{{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}
+  {{ if .OutputFormats.Get "RSS" }}
+  {{ with .OutputFormats.Get "RSS" }}
+    <link href="{{ .RelPermalink }}" rel="alternate" type="application/rss+xml" title="{{ $.Site.Title }}" />
+    <link href="{{ .RelPermalink }}" rel="feed" type="application/rss+xml" title="{{ $.Site.Title }}" />
+  {{ end }}
+  {{ end }}
+
+  {{ if .Params.canonicalUrl }}
+    <link rel="canonical" href="{{ .Params.canonicalUrl }}">
+  {{ else }}
+    <link rel="canonical" href="{{ .Permalink }}">
+  {{ end }}
+
+  {{- template "_internal/opengraph.html" . -}}
+  {{- template "_internal/schema.html" . -}}
+  {{- template "_internal/twitter_cards.html" . -}}
+
+  {{ if eq (getenv "HUGO_ENV") "production" | or (eq .Site.Params.env "production") }}
+    {{ template "_internal/google_analytics.html" . }}
+  {{ end }}
+
+  {{ block "head" . }}{{ partial "head-additions.html" . }}{{ end }}
+
   <link rel="apple-touch-icon" sizes="180x180" href="/favicons/apple-touch-icon.png">
   <link rel="icon" type="image/png" sizes="32x32" href="/favicons/favicon-32x32.png">
   <link rel="icon" type="image/png" sizes="16x16" href="/favicons/favicon-16x16.png">
   <link rel="manifest" href="/favicons/site.webmanifest">
-  </head>
+</head>
 
-  <body class="ma0 {{ $.Param "body_classes"  | default "avenir bg-near-white"}}{{ with getenv "HUGO_ENV" }} {{ . }}{{ end }}">
+<body>
+  {{ block "header" . }}{{ partial "site-header.html" . }}{{ end }}
+  <main role="main">
+    {{ block "main" . }}{{ end }}
+  </main>
+  {{ block "footer" . }}{{ partialCached "site-footer.html" . }}{{ end }}
 
-    {{ block "header" . }}{{ partial "site-header.html" .}}{{ end }}
-    <main class="pb7" role="main">
-      {{ block "main" . }}{{ end }}
-    </main>
-    {{ block "footer" . }}{{ partialCached "site-footer.html" . }}{{ end }}
-  </body>
+  {{/* JS: theme toggle + scroll reveal */}}
+  {{ $js := resources.Get "js/theme-toggle.js" | fingerprint }}
+  <script src="{{ $js.RelPermalink }}" defer></script>
+</body>
 </html>

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,15 +1,71 @@
 {{ define "main" }}
-  <article class="pa3 pa4-ns nested-copy-line-height">
-    <section class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy {{ $.Param "text_color" | default "mid-gray" }}">
-      {{- .Content -}}
-    </section>
-    <section class="flex-ns flex-wrap justify-around mt5">
-      {{ range .Paginator.Pages }}
-        <div class="relative w-100 w-30-l mb4 bg-white">
-          {{ .Render "summary" }}
+{{ $allPosts := .Pages }}
+
+{{/* ── Page header ── */}}
+<section class="page-head">
+  <div class="container">
+    <div class="page-head-grid">
+      <div>
+        <div class="page-head-eyebrow">Writing</div>
+        <h1>{{ .Title | default "The blog." }}</h1>
+      </div>
+      <p>{{ with .Description }}{{ . }}{{ else }}Essays and notes on chemistry, patents, AI tooling, and the craft of deep work. Not on a schedule — just when something is worth writing down.{{ end }}</p>
+    </div>
+  </div>
+</section>
+
+{{/* ── Blog list ── */}}
+<section class="blog-wrap">
+  <div class="container">
+
+    {{/* Toolbar */}}
+    <div class="blog-toolbar">
+      <div class="count">
+        <span class="blog-count">{{ len $allPosts }}</span> essays
+        <strong id="active-tag-label"></strong>
+      </div>
+      <div class="blog-tags">
+        <button class="blog-tag-btn active" data-filter="all">all</button>
+        {{ $tags := slice }}
+        {{ range $allPosts }}
+          {{ range .Params.tags }}
+            {{ $tags = $tags | append . }}
+          {{ end }}
+        {{ end }}
+        {{ range ($tags | uniq) }}
+        <button class="blog-tag-btn" data-filter="{{ . | lower }}">{{ . | lower }}</button>
+        {{ end }}
+      </div>
+    </div>
+
+    {{/* Entry list */}}
+    <div class="blog-list">
+      {{ range $allPosts }}
+      <article class="blog-entry"
+        data-tag="{{ with .Params.tags }}{{ index . 0 | lower }}{{ end }}"
+        onclick="window.location='{{ .RelPermalink }}'">
+        <div class="blog-entry-date">
+          {{ .Date.Format "Jan 02" }}
+          <span class="year">{{ .Date.Format "2006" }}</span>
         </div>
+        <div>
+          {{ with .Params.categories }}<div class="blog-entry-cat">{{ index . 0 }}</div>{{ end }}
+          <h2 class="blog-entry-title">{{ .Title }}</h2>
+          <p class="blog-entry-excerpt">{{ .Summary | truncate 160 }}</p>
+        </div>
+        <div class="blog-entry-meta">
+          {{ if .ReadingTime }}{{ .ReadingTime }} MIN{{ end }}
+          {{ with .Params.tags }}<br>#{{ index . 0 | lower }}{{ end }}
+        </div>
+      </article>
       {{ end }}
-    </section>
-    {{- template "_internal/pagination.html" . -}}
-  </article>
+    </div>
+
+
+</div>
+</section>
+
+{{/* Tag filter JS */}}
+{{ $js := resources.Get "js/tag-filter.js" | fingerprint }}
+<script src="{{ $js.RelPermalink }}" defer></script>
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,77 +1,73 @@
-{{ define "header" }}
-{{/* We can override any block in the baseof file be defining it in the template */}}
-{{ partial "page-header.html" . }}
-{{ end }}
-
 {{ define "main" }}
 {{ $section := .Site.GetPage "section" .Section }}
-<article class="flex-l flex-wrap justify-between mw8 center ph3">
-  <header class="mt4 w-100">
-    <aside class="instapaper_ignoref b helvetica tracked ttu">
-      {{/*
-      CurrentSection allows us to use the section title instead of inferring from the folder.
-      https://gohugo.io/variables/page/#section-variables-and-methods
-      */}}
-      {{ .CurrentSection.Title }}
-    </aside>
 
-    <h1 class="f1 athelas mt3 mb1">
-      {{- .Title -}}
-    </h1>
-    {{ with .Params.author | default .Site.Params.author }}
-    <p class="tracked">
-      {{ $.Render "by" }} <strong>
-        {{- if reflect.IsSlice . -}}
-        {{ delimit . ", " | markdownify }}
-        {{- else -}}
-        {{ . | markdownify }}
-        {{- end -}}
-      </strong>
-    </p>
-    {{ end }}
-    {{/* Hugo uses Go's date formatting is set by example. Here are two formats */}}
-    {{ if not .Date.IsZero }}
-    <time class="f6 mv4 dib tracked" {{ printf `datetime="%s" ` (.Date.Format "2006-01-02T15:04:05Z07:00" ) |
-      safeHTMLAttr }}>
-      {{- .Date | time.Format (default "January 2, 2006" .Site.Params.date_format) -}}
-    </time>
-    {{end}}
+<div class="post-wrap">
 
-    {{/*
-    Show "reading time" and "word count" but only if one of the following are true:
-    1) A global config `params` value is set `show_reading_time = true`
-    2) A section front matter value is set `show_reading_time = true`
-    3) A page front matter value is set `show_reading_time = true`
-    */}}
-    {{ if (or (eq (.Param "show_reading_time") true) (eq $section.Params.show_reading_time true) )}}
-    <span class="f6 mv4 dib tracked"> - {{ i18n "readingTime" .ReadingTime }} </span>
-    <span class="f6 mv4 dib tracked"> - {{ i18n "wordCount" .WordCount }} </span>
-    {{ end }}
-  </header>
-  <div class="flex-l mw8 center">
-    <article class="cf ph3 ph4-ns mw7">
-      <div class="nested-copy-line-height lh-copy f4 nested-links {{ $.Param " text_color" | default "mid-gray" }}"
-        style="text-align: left;">
-        {{ .Content }}
-        <hr>
-        {{/* Related posts */}}
-        {{- partial "related-posts.html" . -}}
-        {{/* Tags */}}
-        {{- partial "tags.html" . -}}
-        {{/* Buy me a coffee */}}
-        {{- partial "buy-me-coffee.html" . -}}
-        {{/* Social share */}}
-        {{- partial "social-share.html" . -}}
-        {{/* Contact form */}}
-        {{- partial "form-contact.html" . -}}
+  {{/* Back link */}}
+  <div class="container">
+    <a href="{{ with $section }}{{ .RelPermalink }}{{ else }}/posts/{{ end }}" class="post-back">
+      ← All essays
+    </a>
+  </div>
 
+  {{/* Post header */}}
+  <div class="post-header container">
+    {{ with .Params.categories }}<div class="cat">{{ index . 0 }}</div>{{ end }}
+    <h1>{{ .Title }}</h1>
+    {{ with .Description }}<p class="lead">{{ . }}</p>{{ else }}{{ with .Summary }}<p class="lead">{{ . | truncate 200 }}</p>{{ end }}{{ end }}
+  </div>
+
+  {{/* Meta bar */}}
+  <div class="container">
+    <div class="post-meta">
+      <div class="author">
+        <div class="avatar"></div>
+        {{ .Site.Params.author | default "Lucas Aguiar" }}
       </div>
-    </article>
+      {{ if not .Date.IsZero }}<span>{{ .Date.Format "January 2, 2006" }}</span>{{ end }}
+      {{ if .ReadingTime }}<span>{{ .ReadingTime }} MIN READ</span>{{ end }}
+    </div>
   </div>
 
-  <div class="flex-l mt2 mw8 center">
-
-
+  {{/* Cover image */}}
+  {{ with .Params.featured_image }}
+  <div class="container">
+    <div class="post-cover">
+      <img src="{{ . }}" alt="{{ $.Title }}">
+    </div>
   </div>
-</article>
+  {{ end }}
+
+  {{/* Body */}}
+  <article class="post-body container">
+    {{ .Content }}
+  </article>
+
+  {{/* Tags */}}
+  {{ with .Params.tags }}
+  <div class="post-tags container">
+    {{ range . }}<span class="post-tag">#{{ . }}</span>{{ end }}
+  </div>
+  {{ end }}
+
+  {{/* Extras: related posts, buy me a coffee, contact form */}}
+  <div class="post-extras">
+    {{- partial "related-posts.html" . -}}
+    {{- partial "buy-me-coffee.html" . -}}
+    {{- partial "form-contact.html" . -}}
+  </div>
+
+  {{/* Prev / Next */}}
+  <div class="container">
+    <div class="post-footer">
+      {{ with .PrevInSection }}
+        <a href="{{ .RelPermalink }}">← {{ .Title | truncate 45 }}</a>
+      {{ else }}<span></span>{{ end }}
+      {{ with .NextInSection }}
+        <a href="{{ .RelPermalink }}">{{ .Title | truncate 45 }} →</a>
+      {{ else }}<span></span>{{ end }}
+    </div>
+  </div>
+
+</div>
 {{ end }}

--- a/layouts/contact/list.html
+++ b/layouts/contact/list.html
@@ -1,9 +1,4 @@
 {{ define "main" }}
-{{ $isContact := eq .RelPermalink "/contact/" }}
-{{ $isPrivacy := or (eq .RelPermalink "/privacy/") (eq .RelPermalink "/privacy-policy/") }}
-
-{{/* ── Contact page ── */}}
-{{ if $isContact }}
 <section class="page-head">
   <div class="container">
     <div class="page-head-grid">
@@ -61,51 +56,4 @@
     </div>
   </div>
 </section>
-
-{{/* ── Privacy page ── */}}
-{{ else if $isPrivacy }}
-<section class="page-head">
-  <div class="container">
-    <div class="page-head-grid">
-      <div>
-        <div class="page-head-eyebrow">Legal</div>
-        <h1>Privacy.</h1>
-      </div>
-      <p>How I handle data on this site. Short version first — full version below.</p>
-    </div>
-  </div>
-</section>
-
-<section class="privacy-wrap">
-  <div class="container">
-    <div class="privacy-grid">
-      <aside class="privacy-toc">
-        <h4>Sections</h4>
-        {{ .TableOfContents }}
-      </aside>
-      <div class="privacy-content">
-        {{ .Content }}
-      </div>
-    </div>
-  </div>
-</section>
-
-{{/* ── Generic page fallback ── */}}
-{{ else }}
-<section class="page-head">
-  <div class="container">
-    <div class="page-head-grid">
-      <div>
-        <h1>{{ .Title }}</h1>
-      </div>
-      {{ with .Description }}<p>{{ . }}</p>{{ end }}
-    </div>
-  </div>
-</section>
-
-<div class="generic-page">
-  {{ .Content }}
-</div>
-{{ end }}
-
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,59 +1,147 @@
 {{ define "main" }}
-<article class="cf ph3 ph5-l pv3 pv4-l f4 tc-l center measure-wide lh-copy {{ $.Param " text_color" | default "mid-gray"
-  }}">
-  {{ .Content }}
-</article>
-{{ partial "buy-me-coffee.html" . }}
-{{/* Define a section to pull recent posts from. For Hugo 0.20 this will default to the section with the most number of
-pages. */}}
-{{ $mainSections := .Site.Params.mainSections | default (slice "post") }}
-{{/* Create a variable with that section to use in multiple places. */}}
-{{ $section := where .Site.RegularPages "Section" "in" $mainSections }}
-{{/* Check to see if the section is defined for ranging through it */}}
-{{ $section_count := len $section }}
-{{ if ge $section_count 1 }}
-{{/* Derive the section name */}}
-{{ $section_name := index (.Site.Params.mainSections) 0 }}
+{{ $mainSections := .Site.Params.mainSections | default (slice "posts") }}
+{{ $posts := where .Site.RegularPages "Section" "in" $mainSections }}
+{{ $featured := index $posts 0 }}
+{{ $recent := after 1 (first 4 $posts) }}
 
-<div class="pa3 pa4-ns w-100 w-70-ns center">
-  {{/* Use $section_name to get the section title. Use "with" to only show it if it exists */}}
-  {{ with .Site.GetPage "section" $section_name }}
-  <h1 class="flex-none">
-    {{ $.Param "recent_copy" | default (i18n "recentTitle" .) }}
-  </h1>
-  {{ end }}
-
-  {{ $n_posts := $.Param "recent_posts_number" | default 3 }}
-
-  <section class="w-100 mw8">
-    {{/* Range through the first $n_posts items of the section */}}
-    {{ range (first $n_posts $section) }}
-    <div class="relative w-100 mb4">
-      {{ .Render "summary-with-image" }}
+{{/* ── Hero ── */}}
+<section class="ed-hero">
+  <div class="container">
+    <div class="ed-hero-grid">
+      <div>
+        <div class="ed-hero-eyebrow fade-up">Essays · Notes · Research</div>
+        <h1 class="fade-up delay-1">
+          A journal on <em>chemistry</em>,<br>
+          intellectual property,<br>
+          and the craft of <em>building</em>.
+        </h1>
+        <div class="ed-hero-meta fade-up delay-2">
+          <div>Written by<strong>Lucas F. Aguiar</strong></div>
+          <div>Based in<strong>Brasília, Brazil</strong></div>
+          <div>Essays<strong>{{ len $posts }}</strong></div>
+        </div>
+      </div>
+      <div class="ed-hero-aside fade-up delay-2">
+        <span class="quote-mark">"</span>
+        The best way I know to understand something is to try to explain it — to students, to clients, to myself, six months later.
+      </div>
     </div>
-    {{ end }}
-  </section>
+  </div>
+</section>
 
-  {{ if ge $section_count (add $n_posts 1) }}
-  <section class="w-100">
-    <h1 class="f3">{{ i18n "more" }}</h1>
-    {{/* Now, range through the next four after the initial $n_posts items. Nest the requirements, "after" then "first"
-    on the outside */}}
-    {{ range (first 4 (after $n_posts $section)) }}
-    <h2 class="f5 fw4 mb4 dib {{ cond (eq $.Site.Language.LanguageDirection " rtl") "ml3" "mr3" }}">
-      <a href="{{ .RelPermalink }}" class="link black dim">
-        {{ .Title }}
+{{/* ── Featured post ── */}}
+{{ with $featured }}
+<section class="ed-featured">
+  <div class="container">
+    <div class="ed-featured-label">
+      <span class="mono-label">The Lead Essay</span>
+      <hr>
+      <span class="mono-label">№ 001</span>
+    </div>
+    <div class="ed-featured-grid">
+      <a href="{{ .RelPermalink }}" class="ed-featured-img">
+        {{ with .Params.featured_image }}
+          <img src="{{ . }}" alt="{{ $.Title }}">
+        {{ else }}
+          <div class="img-placeholder">Featured illustration</div>
+        {{ end }}
       </a>
-    </h2>
-    {{ end }}
-
-    {{/* As above, Use $section_name to get the section title, and URL. Use "with" to only show it if it exists */}}
-    {{ with .Site.GetPage "section" $section_name }}
-    <a href="{{ .RelPermalink }}" class="link db f6 pa2 br3 bg-mid-gray white dim w4 tc">{{ i18n "allTitle" . }}</a>
-    {{ end }}
-  </section>
-  {{ end }}
-
-</div>
+      <div>
+        {{ with .Params.categories }}<div class="ed-featured-cat">{{ index . 0 }}</div>{{ end }}
+        <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
+        <p>{{ .Summary | truncate 200 }}</p>
+        <div class="ed-byline">
+          <span>{{ .Site.Params.author | default "Lucas Aguiar" }}</span>
+          <span class="dot"></span>
+          <span>{{ .Date.Format "Jan 2, 2006" }}</span>
+          {{ if .ReadingTime }}<span class="dot"></span><span>{{ .ReadingTime }} min read</span>{{ end }}
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
 {{ end }}
+
+{{/* ── Recent posts grid ── */}}
+{{ if $recent }}
+<section class="ed-grid">
+  <div class="container">
+    <div class="ed-grid-head">
+      <h2>Recent writing</h2>
+      <a href="/posts/" class="btn-link">All essays</a>
+    </div>
+    <div class="ed-grid-posts">
+      {{ range $i, $p := $recent }}
+      <article class="ed-post reveal" onclick="window.location='{{ $p.RelPermalink }}'">
+        <div class="ed-post-num">№ {{ printf "%03d" (add $i 2) }}</div>
+        {{ with $p.Params.categories }}<div class="ed-post-cat">{{ index . 0 }}</div>{{ end }}
+        <h3><a href="{{ $p.RelPermalink }}">{{ $p.Title }}</a></h3>
+        <p>{{ $p.Summary | truncate 120 }}</p>
+        <div class="ed-post-meta">{{ $p.Date.Format "Jan 2, 2006" }}{{ if $p.ReadingTime }} · {{ $p.ReadingTime }} min{{ end }}</div>
+      </article>
+      {{ end }}
+    </div>
+  </div>
+</section>
+{{ end }}
+
+{{/* ── Pull quote ── */}}
+<section class="ed-pull reveal">
+  <div class="container">
+    <blockquote>
+      "Patents are the technical literature of the future. To draft one well is to <em>commit a possibility</em> to record."
+    </blockquote>
+    <cite>From the about page</cite>
+  </div>
+</section>
+
+{{/* ── What I work on ── */}}
+<section class="ed-work reveal">
+  <div class="container">
+    <div class="ed-work-head">
+      <h2>What I work on</h2>
+      <span class="mono-label">Four practice areas</span>
+    </div>
+    <div class="ed-work-grid">
+      <div class="ed-work-item">
+        <span class="num">01</span>
+        <h3>Patent Prosecution</h3>
+        <p>Drafting and prosecuting applications in chemistry and materials science.</p>
+      </div>
+      <div class="ed-work-item">
+        <span class="num">02</span>
+        <h3>IP Consulting</h3>
+        <p>Strategy, patentability assessments, and commercialization pathways.</p>
+      </div>
+      <div class="ed-work-item">
+        <span class="num">03</span>
+        <h3>Perovskite Research</h3>
+        <p>PhD work on perovskite-based photovoltaics and stability at UnB.</p>
+      </div>
+      <div class="ed-work-item">
+        <span class="num">04</span>
+        <h3>Writing &amp; Teaching</h3>
+        <p>Essays, guest lectures, and mentoring early-career researchers.</p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{/* ── Newsletter / contact CTA ── */}}
+<section class="ed-newsletter reveal">
+  <div class="container">
+    <div class="ed-newsletter-inner">
+      <div>
+        <h2>Get in touch.</h2>
+        <p>Whether it's a patent question, a speaking invitation, or just a note — I read everything and respond to most within a few days.</p>
+      </div>
+      <div>
+        <a href="/contact/" class="btn btn-primary">Start a conversation →</a>
+        <div class="ed-form-note" style="margin-top:16px">Patent drafting · IP strategy · Collaboration</div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{ partial "buy-me-coffee.html" . }}
 {{ end }}

--- a/layouts/page/about.html
+++ b/layouts/page/about.html
@@ -1,40 +1,68 @@
 {{ define "main" }}
-<article class="flex-l mw9 center ph3-l" style="position: relative; z-index: 2;">
-    <!-- TOC Section - Left Column -->
-    <aside class="w-20-l w-100 pr3-l order-1 toc-card">
-        <div class="bg-white pa3 br2 shadow-4 sticky top-2">
-            <h3 class="mt0 mb3">Contents</h3>
-            {{ .TableOfContents }}
-        </div>
-    </aside>
-
-    <!-- Main Content - Center Column -->
-    <div class="w-55-l w-100 ph3-l order-2 nested-copy-line-height lh-copy">
-        <div class="mw7 center">
-            {{ .Content }}
-        </div>
+{{/* ── Page header ── */}}
+<section class="page-head">
+  <div class="container">
+    <div class="page-head-grid">
+      <div>
+        <div class="page-head-eyebrow">About</div>
+        <h1>Patent prosecutor,<br>IP consultant,<br>researcher.</h1>
+      </div>
+      <p>I'm a Brazilian chemist specialized in intellectual property. I work at the Ministry of Health as a technical consultant and pursue a PhD at UnB on perovskite photovoltaics.</p>
     </div>
+  </div>
+</section>
 
-    <!-- Profile Section - Right Column -->
-    <aside class="w-25-l w-100 pl3-l order-3">
-        <div class="profile-card sticky top-2 bg-white pa3 br2 shadow-4">
-            <div class="circle-mask mb3">
-                <img src="https://lucasaguiarxyzstorage.blob.core.windows.net/images/lucas-perfil-2022.jpg"
-                    alt="Lucas Aguiar" class="w-100">
-            </div>
-            <div class="social-links flex flex-column">
-                <a href="https://github.com/isfttr" class="link black hover-blue dib mv2" target="_blank"><i
-                        class="fab fa-github mr2"></i>GitHub</a>
-                <a href="https://linkedin.com/in/lucas-fernandes-aguiar" class="link black hover-blue dib mv2"
-                    target="_blank"><i class="fab fa-linkedin mr2"></i>LinkedIn</a>
-                <a href="https://buymeacoffee.com/lucasaguiar" class="link black hover-blue dib mv2" target="_blank"><i
-                        class="fa-solid fa-coffee mr2"></i>Buy
-                    Me a Coffee</a>
-            </div>
-            <p class="mt3">Hi, my name is Lucas Fernandes Aguiar, brazilian chemist, specialized in
-                intellectual property, currently working at Ministério da Saúde (MS) and as
-                a PhD student at the Ceramic Materials and Nanotechnology Laboratory (LMCNano/FT/UnB).</p>
+{{/* ── 3-column layout ── */}}
+<section class="about-wrap">
+  <div class="container">
+    <div class="about-grid">
+
+      {{/* Left: TOC */}}
+      <aside class="about-toc">
+        <h4>Contents</h4>
+        {{ .TableOfContents }}
+      </aside>
+
+      {{/* Center: content from markdown — kept as-is per user request */}}
+      <div class="about-content">
+        {{ .Content }}
+      </div>
+
+      {{/* Right: profile sidebar */}}
+      <aside class="about-side">
+        <div class="about-portrait">
+          <img src="https://lucasaguiarxyzstorage.blob.core.windows.net/images/lucas-perfil-2022.jpg" alt="Lucas Aguiar">
         </div>
-    </aside>
-</article>
+
+        <div class="about-card">
+          <h4>Find me</h4>
+          <div class="links">
+            {{ range .Site.Params.ananke_socials }}
+            <a href="{{ .url }}" target="_blank" rel="noopener">
+              <span class="glyph">{{ upper (substr .name 0 2) }}</span>{{ .label }}
+            </a>
+            {{ end }}
+            <a href="/contact/">
+              <span class="glyph">@</span>contact@lucasaguiar.xyz
+            </a>
+            <a href="https://buymeacoffee.com/lucasaguiar" target="_blank" rel="noopener">
+              <span class="glyph">☕</span>Buy Me a Coffee
+            </a>
+          </div>
+        </div>
+
+        <div class="about-card">
+          <h4>Consulting</h4>
+          <p style="font-size:14px;color:var(--fg-muted);line-height:1.55;margin-bottom:12px">Available for patent drafting, IP strategy, and FTO analyses.</p>
+          <a href="/contact/" class="btn btn-primary" style="width:100%;justify-content:center;display:inline-flex">Get in touch →</a>
+        </div>
+
+        <div class="about-bmc">
+          {{ partial "buy-me-coffee.html" . }}
+        </div>
+      </aside>
+
+    </div>
+  </div>
+</section>
 {{ end }}

--- a/layouts/page/list.html
+++ b/layouts/page/list.html
@@ -1,0 +1,48 @@
+{{ define "main" }}
+{{ if eq .Section "privacy-policy" }}
+
+<section class="page-head">
+  <div class="container">
+    <div class="page-head-grid">
+      <div>
+        <div class="page-head-eyebrow">Legal</div>
+        <h1>Privacy.</h1>
+      </div>
+      <p>How I handle data on this site. Short, honest version first — full version below.</p>
+    </div>
+  </div>
+</section>
+
+<section class="privacy-wrap">
+  <div class="container">
+    <div class="privacy-grid">
+      <aside class="privacy-toc">
+        <h4>Sections</h4>
+        {{ .TableOfContents }}
+      </aside>
+      <div class="privacy-content">
+        {{ .Content }}
+      </div>
+    </div>
+  </div>
+</section>
+
+{{ else }}
+
+<section class="page-head">
+  <div class="container">
+    <div class="page-head-grid">
+      <div>
+        <h1>{{ .Title }}</h1>
+      </div>
+      {{ with .Description }}<p>{{ . }}</p>{{ end }}
+    </div>
+  </div>
+</section>
+
+<div class="generic-page">
+  {{ .Content }}
+</div>
+
+{{ end }}
+{{ end }}

--- a/layouts/partials/buy-me-coffee.html
+++ b/layouts/partials/buy-me-coffee.html
@@ -1,5 +1,14 @@
-<div class="tc mt2 mb2">
-    <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js" data-name="bmc-button"
-        data-slug="lucasaguiar" data-color="#FFDD00" data-emoji="" data-font="Cookie" data-text="Buy me a coffee"
-        data-outline-color="#000000" data-font-color="#000000" data-coffee-color="#ffffff"></script>
+<div class="bmc-wrap">
+  <div class="bmc-label">If this was useful</div>
+  <script type="text/javascript" src="https://cdnjs.buymeacoffee.com/1.0.0/button.prod.min.js"
+    data-name="bmc-button"
+    data-slug="lucasaguiar"
+    data-color="#FFDD00"
+    data-emoji=""
+    data-font="Cookie"
+    data-text="Buy me a coffee"
+    data-outline-color="#000000"
+    data-font-color="#000000"
+    data-coffee-color="#ffffff">
+  </script>
 </div>

--- a/layouts/partials/form-contact.html
+++ b/layouts/partials/form-contact.html
@@ -1,55 +1,27 @@
-{{ $.Scratch.Add "labelClasses" "f6 b db mb1 mt3 sans-serif mid-gray" }}
-{{ $.Scratch.Add "inputClasses" "w-100 f5 pv3 ph3 bg-light-gray bn" }}
-
 <form action="https://formspree.io/f/xgeglgop" method="POST">
-  <label>
-    <input type="email" name="email" placeholder="Your e-mail address">
-  </label>
-  <hr>
-  <label>
-    <textarea rows="10" cols="50" name="message" placeholder="Type your message here..."></textarea>
-  </label>
-
-  <!-- your other form fields go here -->
-  <button type="submit">Send</button>
+  <div class="form-row">
+    <label for="fc-name">Your name</label>
+    <input type="text" id="fc-name" name="name" required placeholder="Lucas Silva">
+  </div>
+  <div class="form-row">
+    <label for="fc-email">Your email</label>
+    <input type="email" id="fc-email" name="email" required placeholder="you@domain.com">
+  </div>
+  <div class="form-row">
+    <label for="fc-subject">About</label>
+    <select id="fc-subject" name="subject">
+      <option>IP consulting</option>
+      <option>Patent drafting</option>
+      <option>Research collaboration</option>
+      <option>Speaking / teaching</option>
+      <option>Just saying hi</option>
+    </select>
+  </div>
+  <div class="form-row">
+    <label for="fc-message">Your message</label>
+    <textarea id="fc-message" name="message" required placeholder="Keep it short if you can — I read everything."></textarea>
+  </div>
+  <button type="submit" class="btn btn-primary" style="width:100%;justify-content:center;margin-top:8px">
+    Send message →
+  </button>
 </form>
-
-<style>
-  /* Some nice boilerplate CSS to tidy up your form */
-  form {
-    display: block;
-    /* grid-template-columns: max-content 1fr; */
-    grid-gap: 10rem;
-    /* Keep grid-gap for spacing */
-    text-align: center;
-    padding: 2rem 0;
-    margin: 0;
-  }
-
-  form label {
-    display: contents;
-  }
-
-  form input[type="email"],
-  form textarea {
-    width: 100%;
-  }
-
-  form button {
-    font-family: inherit;
-    font-size: inherit;
-    border: 1px solid currentColor;
-    background: none;
-    padding: 0.5rem 0.5rem;
-    border-radius: 10px;
-  }
-
-  form textarea {
-    resize: vertical;
-  }
-
-  form button {
-    justify-self: center;
-    border-radius: 10px;
-  }
-</style>

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -1,14 +1,67 @@
-<footer class="{{ .Site.Params.background_color_class | default " bg-black" }} bottom-0 w-100 pa3" role="contentinfo">
-  <div class="flex justify-between items-center">
-    <a class="f4 fw4 hover-white no-underline white-70 dn dib-ns pv2 ph3" href="{{ .Site.Home.Permalink }}">
-      &copy; Lucas Fernandes Aguiar 2023 - {{ now.Format "2006"}}. All rights reserved.
-    </a>
-    <div class="flex items-center">
-      {{ partial "privacy-policy.html" . }}
+<footer class="site-footer">
+  <div class="container">
+    <div class="footer-grid">
+      <div class="footer-col">
+        <div class="footer-brand-name">Lucas Aguiar</div>
+        <p class="footer-brand-desc">Patent prosecutor and researcher. Writing about intellectual property, chemistry, and how I use AI to work smarter.</p>
+        <div class="footer-socials">
+          {{ range .Site.Params.ananke_socials }}
+            {{ if eq .name "github" }}
+              <a href="{{ .url }}" target="_blank" rel="noopener" aria-label="GitHub">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M9 19c-5 1.5-5-2.5-7-3m14 6v-3.87a3.37 3.37 0 0 0-.94-2.61c3.14-.35 6.44-1.54 6.44-7A5.44 5.44 0 0 0 20 4.77 5.07 5.07 0 0 0 19.91 1S18.73.65 16 2.48a13.38 13.38 0 0 0-7 0C6.27.65 5.09 1 5.09 1A5.07 5.07 0 0 0 5 4.77a5.44 5.44 0 0 0-1.5 3.78c0 5.42 3.3 6.61 6.44 7A3.37 3.37 0 0 0 9 18.13V22"/></svg>
+              </a>
+            {{ end }}
+            {{ if eq .name "linkedin" }}
+              <a href="{{ .url }}" target="_blank" rel="noopener" aria-label="LinkedIn">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M16 8a6 6 0 0 1 6 6v7h-4v-7a2 2 0 0 0-4 0v7h-4v-7a6 6 0 0 1 6-6z"/><rect x="2" y="9" width="4" height="12"/><circle cx="4" cy="4" r="2"/></svg>
+              </a>
+            {{ end }}
+            {{ if eq .name "threads" }}
+              <a href="{{ .url }}" target="_blank" rel="noopener" aria-label="Threads">
+                <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M19 7.5c-1.333-3-3.667-4.5-7-4.5C7.5 3 4 6.5 4 12s3.5 9 8 9c3 0 5.5-1 7-4"/><path d="M15 11c-.667-2-2-3-4-3s-3.5 1.5-3.5 4 1.5 4 3.5 4c1.5 0 2.5-.5 3-1.5"/></svg>
+              </a>
+            {{ end }}
+          {{ end }}
+          <a href="/contact/" aria-label="Email">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><rect x="2" y="4" width="20" height="16" rx="2"/><path d="m22 7-10 5L2 7"/></svg>
+          </a>
+          {{ if .OutputFormats.Get "RSS" }}
+          <a href="{{ (.OutputFormats.Get "RSS").RelPermalink }}" aria-label="RSS feed">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M4 11a9 9 0 0 1 9 9"/><path d="M4 4a16 16 0 0 1 16 16"/><circle cx="5" cy="19" r="1"/></svg>
+          </a>
+          {{ end }}
+        </div>
+      </div>
+
+      <div class="footer-col">
+        <h4>Site</h4>
+        <a href="{{ .Site.Home.RelPermalink }}">Home</a>
+        <a href="/posts/">Blog</a>
+        <a href="/about/">About</a>
+        <a href="/contact/">Contact</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Practice</h4>
+        <a href="/about/">Patent Prosecution</a>
+        <a href="/about/">IP Consulting</a>
+        <a href="/about/">Research</a>
+        <a href="/about/">PhD Work</a>
+      </div>
+
+      <div class="footer-col">
+        <h4>Elsewhere</h4>
+        {{ range .Site.Params.ananke_socials }}
+          <a href="{{ .url }}" target="_blank" rel="noopener">{{ .label }}</a>
+        {{ end }}
+        <a href="http://lattes.cnpq.br" target="_blank" rel="noopener">Lattes CV</a>
+        {{ partial "privacy-policy.html" . }}
+      </div>
     </div>
-    <div class="flex items-center">
-      {{ partial "repo-version.html" . }}
-      <div class="ml3">{{ partial "social-follow.html" . }}</div>
+
+    <div class="footer-bottom">
+      <span>&copy; {{ now.Format "2006" }} Lucas Fernandes Aguiar. All rights reserved.</span>
+      <span>Brasília, Brazil</span>
     </div>
   </div>
 </footer>

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -1,35 +1,35 @@
-{{ $featured_image := partial "func/GetFeaturedImage.html" . }}
-{{ if $featured_image }}
-  {{/* Trimming the slash and adding absURL make sure the image works no matter where our site lives */}}
-  <header class="cover bg-top" style="background-image: url('{{ $featured_image }}');">
-    <div class="{{ .Site.Params.cover_dimming_class | default "bg-black-60" }}">
-      {{ partial "site-navigation.html" .}}
-      <div class="tc-l pv4 pv6-l ph3 ph4-ns">
-        <h1 class="f2 f-subheadline-l fw2 white-90 mb0 lh-title">
-          {{ .Title | default .Site.Title }}
-        </h1>
-        {{ with .Params.description }}
-          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center mt3">
-            {{ . }}
-          </h2>
-        {{ end }}
+{{ $currentPage := . }}
+<nav class="nav-shell">
+  <div class="container">
+    <div class="nav-inner">
+      <a href="{{ .Site.Home.RelPermalink }}" class="nav-brand">
+        <span class="monogram">L</span>
+        <span>Lucas Aguiar</span>
+      </a>
+
+      <div class="nav-right">
+        <div class="nav-links">
+          <a href="/posts/"{{ if eq .Section "posts" }} class="active"{{ end }}>Blog</a>
+          <a href="/about/"{{ if eq .RelPermalink "/about/" }} class="active"{{ end }}>About</a>
+          <a href="/contact/"{{ if eq .RelPermalink "/contact/" }} class="active"{{ end }}>Contact</a>
+        </div>
+        <div class="nav-ctrls">
+          <button class="theme-toggle" id="theme-toggle-btn" aria-label="Toggle dark mode" title="Toggle dark mode">
+            {{/* Icon injected by theme-toggle.js */}}
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M21 12.79A9 9 0 1 1 11.21 3 7 7 0 0 0 21 12.79z"/></svg>
+          </button>
+          <button class="nav-menu-btn" id="nav-menu-btn" aria-label="Open menu">
+            <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
+          </button>
+        </div>
       </div>
     </div>
-  </header>
-{{ else }}
-  <header>
-    <div class="pb3-m pb6-l {{ .Site.Params.background_color_class | default "bg-black" }}">
-      {{ partial "site-navigation.html" . }}
-      <div class="tc-l pv3 ph3 ph4-ns">
-        <h1 class="f2 f-subheadline-l fw2 light-silver mb0 lh-title">
-          {{ .Title | default .Site.Title }}
-        </h1>
-        {{ with .Params.description }}
-          <h2 class="fw1 f5 f3-l white-80 measure-wide-l center lh-copy mt3 mb4">
-            {{ . }}
-          </h2>
-        {{ end }}
-      </div>
+
+    {{/* Mobile nav */}}
+    <div class="nav-mobile" id="nav-mobile">
+      <a href="/posts/"{{ if eq .Section "posts" }} style="color:var(--fg)"{{ end }}>Blog</a>
+      <a href="/about/"{{ if eq .RelPermalink "/about/" }} style="color:var(--fg)"{{ end }}>About</a>
+      <a href="/contact/"{{ if eq .RelPermalink "/contact/" }} style="color:var(--fg)"{{ end }}>Contact</a>
     </div>
-  </header>
-{{ end }}
+  </div>
+</nav>

--- a/layouts/partials/site-style.html
+++ b/layouts/partials/site-style.html
@@ -1,9 +1,2 @@
-{{ with partialCached "func/style/GetMainCSS" "style/GetMainCSS" }}
-<link rel="stylesheet" href="{{ .RelPermalink }}" >
-{{ end }}
-
-{{ range site.Params.custom_css }}
-  {{ with partialCached "func/style/GetResource" . . }}{{ else }}
-    <link rel="stylesheet" href="{{ relURL (.) }}">
-  {{ end }}
-{{ end }}
+{{ $css := resources.Get "css/main.css" | fingerprint }}
+<link rel="stylesheet" href="{{ $css.RelPermalink }}">

--- a/layouts/privacy-policy/list.html
+++ b/layouts/privacy-policy/list.html
@@ -1,0 +1,27 @@
+{{ define "main" }}
+<section class="page-head">
+  <div class="container">
+    <div class="page-head-grid">
+      <div>
+        <div class="page-head-eyebrow">Legal</div>
+        <h1>Privacy.</h1>
+      </div>
+      <p>How I handle data on this site. Short, honest version first — full version below.</p>
+    </div>
+  </div>
+</section>
+
+<section class="privacy-wrap">
+  <div class="container">
+    <div class="privacy-grid">
+      <aside class="privacy-toc">
+        <h4>Sections</h4>
+        {{ .TableOfContents }}
+      </aside>
+      <div class="privacy-content">
+        {{ .Content }}
+      </div>
+    </div>
+  </div>
+</section>
+{{ end }}

--- a/layouts/shortcodes/social_media.html
+++ b/layouts/shortcodes/social_media.html
@@ -1,6 +1,9 @@
-<div class="social-links flex flex-column">
+<div class="about-card" style="max-width:480px;margin:var(--space-5) 0">
+  <h4>Find me</h4>
+  <div class="links">
     {{ partial "github.html" . }}
     {{ partial "linkedin.html" . }}
-    {{ partial "buy-me-coffee.html" . }}
     {{ partial "threads.html" . }}
+  </div>
+  {{ partial "buy-me-coffee.html" . }}
 </div>


### PR DESCRIPTION
Total visual redesign replacing Ananke/Tachyons with a bespoke "Editorial Classic" design system. Ananke stays in the module graph but its CSS is completely suppressed via a site-style.html override.

Design system highlights:
- Navy/gelo palette with full dark mode (localStorage + FOUC prevention)
- Fraunces serif + Inter sans + JetBrains Mono from Google Fonts
- Hugo Pipes fingerprinted CSS/JS for cache-busting
- CSS custom property token system (semantic --bg/--fg/--accent)

New layouts:
- Editorial home: hero, featured post, 3-col recent grid, work areas, CTA
- Blog list with client-side tag filter (vanilla JS, no pagination)
- Single post: drop cap, meta bar, cover image, Buy Me a Coffee + Formspree
- About: 3-col (TOC sidebar / content / profile sidebar)
- Contact: channel cards + Formspree form (endpoint preserved)
- Privacy: sticky TOC + content body
- Dedicated section templates for contact/ and privacy-policy/ to handle _index.md branch bundles routing correctly in Hugo

Preserves: Buy Me a Coffee (data-slug="lucasaguiar"), Formspree (action="https://formspree.io/f/xgeglgop"), all markdown content.