### PR TITLE
feat: add conversion funnel — newsletter CTAs, consulting page, PostH…

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1512,4 +1512,693 @@ a { color: inherit; text-decoration: none; }
 .generic-page p { margin-bottom: var(--space-4); color: var(--fg-muted); }
 .generic-page a { color: var(--accent); }
 .generic-page ul { margin-left: var(--space-5); margin-bottom: var(--space-4); }
+
+/* =========================================================
+   CONVERSION COMPONENTS — v2 funnel additions
+   Nav Subscribe pill, hero pill, newsletter band, inline
+   post CTA, end-of-post author block, sticky float, progress
+   ========================================================= */
+
+/* Reading progress bar */
+.read-progress {
+  position: fixed;
+  top: 0; left: 0;
+  height: 2px;
+  background: var(--accent);
+  z-index: 60;
+  transition: width 0.05s linear;
+  width: 0;
+  pointer-events: none;
+}
+
+/* Nav Subscribe pill */
+.nav-cta {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 6px 14px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 100px;
+  letter-spacing: 0.005em;
+  transition: background 0.2s, transform 0.2s;
+  cursor: pointer;
+  margin-left: var(--space-3);
+  white-space: nowrap;
+}
+.nav-cta:hover {
+  background: var(--accent-hover);
+  transform: translateY(-1px);
+}
+.nav-cta .glyph {
+  width: 6px; height: 6px;
+  background: currentColor;
+  border-radius: 50%;
+  opacity: 0.7;
+}
+@media (max-width: 700px) {
+  .nav-cta { display: none; }
+}
+
+/* Hero subscribe pill */
+.ed-hero-pill {
+  display: inline-flex;
+  align-items: center;
+  gap: var(--space-3);
+  margin-top: var(--space-5);
+  padding: 10px 18px 10px 14px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.04em;
+  color: var(--fg-muted);
+  cursor: pointer;
+  transition: border-color 0.2s, color 0.2s, transform 0.2s;
+  text-decoration: none;
+}
+.ed-hero-pill:hover {
+  border-color: var(--accent);
+  color: var(--fg);
+  transform: translateY(-1px);
+}
+.ed-hero-pill .badge {
+  background: var(--accent);
+  color: var(--accent-fg);
+  padding: 2px 8px;
+  border-radius: 100px;
+  font-family: var(--font-sans);
+  font-size: 10px;
+  font-weight: 500;
+  letter-spacing: 0.05em;
+  text-transform: uppercase;
+}
+.ed-hero-pill .arr { color: var(--accent); }
+
+/* Newsletter band — homepage upgrade */
+.ed-newsletter {
+  background: var(--bg-elevated);
+}
+.ed-newsletter .ed-form-row {
+  display: flex;
+  gap: var(--space-2);
+  align-items: stretch;
+}
+.ed-newsletter .ed-form-row input {
+  flex: 1;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-serif);
+  font-size: 17px;
+  color: var(--fg);
+  outline: none;
+  border-radius: 2px;
+  transition: border-color 0.15s;
+}
+.ed-newsletter .ed-form-row input:focus { border-color: var(--accent); }
+.ed-newsletter .ed-form-row button {
+  padding: 14px 22px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  border-radius: 2px;
+  white-space: nowrap;
+  border: none;
+  cursor: pointer;
+  transition: background 0.15s, transform 0.15s;
+}
+.ed-newsletter .ed-form-row button:hover { background: var(--accent-hover); transform: translateY(-1px); }
+.ed-newsletter-deliverables {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-5);
+  margin-top: var(--space-4);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+}
+.ed-newsletter-deliv {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--fg-muted);
+}
+.ed-newsletter-deliv::before {
+  content: '◆';
+  color: var(--accent);
+  font-size: 9px;
+}
+.ed-newsletter-success {
+  display: none;
+  margin-top: var(--space-3);
+  padding: var(--space-3) var(--space-4);
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+}
+.ed-newsletter-success.show { display: block; }
+
+/* Inline mid-post CTA */
+.post-inline-cta {
+  max-width: 680px;
+  margin: var(--space-7) auto;
+  padding: var(--space-6);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  border-left: 3px solid var(--accent);
+  font-family: var(--font-sans);
+}
+.post-inline-cta .label {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--space-3);
+}
+.post-inline-cta h4 {
+  font-family: var(--font-serif);
+  font-size: 22px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  font-weight: 500;
+  margin-bottom: var(--space-2);
+  color: var(--fg);
+}
+.post-inline-cta p {
+  font-family: var(--font-sans);
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-4);
+}
+.post-inline-cta .ic-form {
+  display: flex;
+  gap: var(--space-2);
+}
+.post-inline-cta input {
+  flex: 1;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  color: var(--fg);
+  outline: none;
+  border-radius: 2px;
+  transition: border-color 0.15s;
+}
+.post-inline-cta input:focus { border-color: var(--accent); }
+.post-inline-cta button {
+  padding: 10px 16px;
+  background: var(--fg);
+  color: var(--bg);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  font-weight: 500;
+  border-radius: 2px;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+.post-inline-cta button:hover { background: var(--accent); color: var(--accent-fg); }
+.post-inline-cta .micro {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.08em;
+  color: var(--fg-faint);
+  margin-top: var(--space-3);
+  text-transform: uppercase;
+}
+.post-inline-success {
+  display: none;
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-align: center;
+  border: 1px dashed var(--accent);
+  border-radius: 2px;
+  margin-top: var(--space-3);
+}
+.post-inline-success.show { display: block; }
+@media (max-width: 600px) {
+  .post-inline-cta .ic-form { flex-direction: column; }
+}
+
+/* End-of-post author + offer block */
+.post-end-cta {
+  max-width: 920px;
+  margin: var(--space-9) auto var(--space-7);
+  padding: var(--space-7) var(--space-6);
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  position: relative;
+  overflow: hidden;
+  font-family: var(--font-sans);
+}
+.post-end-cta::before {
+  content: '';
+  position: absolute;
+  top: 0; left: 0;
+  width: 4px; height: 100%;
+  background: var(--accent);
+}
+.post-end-cta-grid {
+  display: grid;
+  grid-template-columns: 100px 1fr;
+  gap: var(--space-6);
+  align-items: start;
+}
+.post-end-avatar {
+  width: 100px; height: 100px;
+  background: var(--bg-sunken);
+  border-radius: 50%;
+  overflow: hidden;
+  border: 1px solid var(--border);
+  flex-shrink: 0;
+}
+.post-end-avatar img {
+  width: 100%; height: 100%;
+  object-fit: cover;
+  border-radius: 50%;
+}
+.post-end-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--space-3);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.post-end-eyebrow::before {
+  content: '';
+  width: 24px; height: 1px;
+  background: var(--accent);
+}
+.post-end-cta h3 {
+  font-family: var(--font-serif);
+  font-size: clamp(24px, 3vw, 34px);
+  line-height: 1.15;
+  letter-spacing: -0.02em;
+  font-weight: 500;
+  color: var(--fg);
+  margin-bottom: var(--space-3);
+}
+.post-end-cta h3 em {
+  color: var(--accent);
+  font-style: italic;
+}
+.post-end-bio {
+  font-size: 14px;
+  line-height: 1.6;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-5);
+}
+.post-end-creds {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-3) var(--space-5);
+  padding: var(--space-4) 0;
+  margin-bottom: var(--space-5);
+  border-top: 1px solid var(--border);
+  border-bottom: 1px solid var(--border);
+}
+.post-end-cred {
+  display: flex;
+  align-items: center;
+  gap: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--fg-muted);
+  text-transform: uppercase;
+}
+.post-end-cred::before {
+  content: '◆';
+  color: var(--accent);
+  font-size: 8px;
+}
+.post-end-offer {
+  display: flex;
+  align-items: stretch;
+  gap: var(--space-2);
+  margin-top: var(--space-2);
+}
+.post-end-offer input {
+  flex: 1;
+  padding: 14px 16px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-sans);
+  font-size: 15px;
+  color: var(--fg);
+  outline: none;
+  border-radius: 2px;
+  transition: border-color 0.15s;
+}
+.post-end-offer input:focus { border-color: var(--accent); }
+.post-end-offer button {
+  padding: 14px 22px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-family: var(--font-sans);
+  font-size: 14px;
+  font-weight: 500;
+  letter-spacing: 0.005em;
+  border-radius: 2px;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s, transform 0.15s;
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+}
+.post-end-offer button:hover { background: var(--accent-hover); transform: translateY(-1px); }
+.post-end-micro {
+  display: flex;
+  gap: var(--space-4);
+  margin-top: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.1em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  flex-wrap: wrap;
+}
+.post-end-micro span { display: inline-flex; align-items: center; gap: 6px; }
+.post-end-micro span::before { content: '✓'; color: var(--accent); font-size: 11px; }
+.post-end-end-success {
+  padding: var(--space-5);
+  background: color-mix(in oklab, var(--accent) 10%, transparent);
+  border: 1px solid var(--accent);
+  border-radius: 2px;
+  font-family: var(--font-serif);
+  font-size: 18px;
+  color: var(--fg);
+  display: none;
+  margin-top: var(--space-3);
+}
+.post-end-end-success.show { display: block; }
+.post-end-end-success strong {
+  color: var(--accent);
+  display: block;
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  margin-bottom: 6px;
+}
+@media (max-width: 700px) {
+  .post-end-cta-grid { grid-template-columns: 1fr; }
+  .post-end-avatar { width: 72px; height: 72px; }
+  .post-end-offer { flex-direction: column; }
+  .post-end-offer button { justify-content: center; }
+}
+
+/* Sticky floating CTA (bottom-left) */
+.sticky-cta {
+  position: fixed;
+  bottom: 24px;
+  left: 24px;
+  z-index: 195;
+  width: 320px;
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  box-shadow: 0 16px 40px -10px rgba(10, 31, 68, 0.18);
+  padding: var(--space-4);
+  font-family: var(--font-sans);
+  border-radius: 4px;
+  transform: translateY(calc(100% + 40px));
+  opacity: 0;
+  transition: transform 0.5s cubic-bezier(0.16, 1, 0.3, 1), opacity 0.4s;
+  pointer-events: none;
+}
+.sticky-cta.visible {
+  transform: translateY(0);
+  opacity: 1;
+  pointer-events: auto;
+}
+.sticky-cta-close {
+  position: absolute;
+  top: 8px; right: 8px;
+  width: 22px; height: 22px;
+  display: grid; place-items: center;
+  color: var(--fg-faint);
+  border-radius: 2px;
+  background: none;
+  border: none;
+  cursor: pointer;
+  transition: color 0.15s, background 0.15s;
+  font-size: 14px;
+}
+.sticky-cta-close:hover { color: var(--fg); background: var(--bg-sunken); }
+.sticky-cta-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  color: var(--accent);
+  text-transform: uppercase;
+  margin-bottom: var(--space-2);
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+.sticky-cta-eyebrow .live {
+  width: 6px; height: 6px;
+  background: var(--accent);
+  border-radius: 50%;
+  animation: pulse 2s ease-in-out infinite;
+}
+@keyframes pulse { 0%, 100% { opacity: 1; } 50% { opacity: 0.3; } }
+.sticky-cta-title {
+  font-family: var(--font-serif);
+  font-size: 18px;
+  line-height: 1.25;
+  letter-spacing: -0.01em;
+  color: var(--fg);
+  margin-bottom: var(--space-2);
+  font-weight: 500;
+  padding-right: var(--space-4);
+}
+.sticky-cta-desc {
+  font-size: 13px;
+  line-height: 1.5;
+  color: var(--fg-muted);
+  margin-bottom: var(--space-3);
+}
+.sticky-cta-form {
+  display: flex;
+  gap: 6px;
+}
+.sticky-cta-form input {
+  flex: 1;
+  padding: 8px 10px;
+  border: 1px solid var(--border);
+  background: var(--bg);
+  font-family: var(--font-sans);
+  font-size: 13px;
+  color: var(--fg);
+  outline: none;
+  border-radius: 2px;
+  min-width: 0;
+  transition: border-color 0.15s;
+}
+.sticky-cta-form input:focus { border-color: var(--accent); }
+.sticky-cta-form button {
+  padding: 8px 12px;
+  background: var(--accent);
+  color: var(--accent-fg);
+  font-family: var(--font-sans);
+  font-size: 12px;
+  font-weight: 500;
+  border-radius: 2px;
+  border: none;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: background 0.15s;
+}
+.sticky-cta-form button:hover { background: var(--accent-hover); }
+.sticky-cta-micro {
+  margin-top: var(--space-2);
+  font-family: var(--font-mono);
+  font-size: 9px;
+  letter-spacing: 0.1em;
+  color: var(--fg-faint);
+  text-transform: uppercase;
+}
+.sticky-cta-success {
+  padding: var(--space-3);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  color: var(--accent);
+  text-align: center;
+  border: 1px dashed var(--accent);
+  border-radius: 2px;
+  display: none;
+}
+.sticky-cta-success.show { display: block; }
+@media (max-width: 600px) {
+  .sticky-cta { left: 12px; right: 12px; width: auto; bottom: 12px; }
+}
+
+/* Consulting page */
+.page-head {
+  padding: var(--space-9) 0 var(--space-8);
+  border-bottom: 1px solid var(--border);
+}
+.page-head-grid {
+  display: grid;
+  grid-template-columns: 1fr 1fr;
+  gap: var(--space-8);
+  align-items: end;
+}
+.page-head-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+  margin-bottom: var(--space-4);
+  display: flex;
+  align-items: center;
+  gap: var(--space-3);
+}
+.page-head-eyebrow::before {
+  content: '';
+  width: 32px; height: 1px;
+  background: var(--accent);
+}
+.page-head h1 {
+  font-family: var(--font-serif);
+  font-weight: 300;
+  font-size: clamp(42px, 7vw, 80px);
+  line-height: 0.98;
+  letter-spacing: -0.03em;
+  color: var(--fg);
+}
+.page-head p {
+  font-family: var(--font-serif);
+  font-size: 20px;
+  line-height: 1.55;
+  color: var(--fg-muted);
+  max-width: 480px;
+  align-self: end;
+}
+.mo-expertise {
+  padding: var(--space-8) 0;
+}
+.mo-expertise-grid {
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: var(--space-5);
+}
+.mo-area {
+  background: var(--bg-elevated);
+  border: 1px solid var(--border);
+  padding: var(--space-6);
+  transition: border-color 0.3s, transform 0.3s;
+  position: relative;
+  overflow: hidden;
+}
+.mo-area:hover { border-color: var(--accent); transform: translateY(-4px); }
+.mo-area::before {
+  content: '';
+  position: absolute;
+  left: 0; top: 0;
+  width: 3px; height: 30px;
+  background: var(--accent);
+  transition: height 0.3s ease;
+}
+.mo-area:hover::before { height: 100%; }
+.mo-area .num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.1em;
+  color: var(--fg-faint);
+  margin-bottom: var(--space-4);
+}
+.mo-area h3 {
+  font-family: var(--font-serif);
+  font-size: 24px;
+  font-weight: 500;
+  margin-bottom: var(--space-3);
+  letter-spacing: -0.01em;
+  color: var(--fg);
+}
+.mo-area p {
+  font-size: 14px;
+  line-height: 1.55;
+  color: var(--fg-muted);
+}
+.mo-cta {
+  padding: var(--space-9) 0;
+  background: var(--fg);
+  color: var(--bg);
+  text-align: center;
+  position: relative;
+  overflow: hidden;
+}
+.mo-cta::before, .mo-cta::after {
+  content: '';
+  position: absolute;
+  width: 200px; height: 200px;
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: 50%;
+  pointer-events: none;
+}
+.mo-cta::before { top: -60px; left: -60px; }
+.mo-cta::after { bottom: -60px; right: -60px; width: 300px; height: 300px; }
+.mo-cta-eyebrow {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.15em;
+  text-transform: uppercase;
+  color: var(--accent);
+  margin-bottom: var(--space-4);
+}
+.mo-cta h2 {
+  font-family: var(--font-serif);
+  font-size: clamp(32px, 4.5vw, 52px);
+  line-height: 1.1;
+  letter-spacing: -0.02em;
+  font-weight: 400;
+  max-width: 700px;
+  margin: 0 auto var(--space-5);
+}
+.mo-cta .btn-primary {
+  background: var(--bg);
+  color: var(--fg);
+  position: relative;
+  z-index: 1;
+}
+.mo-cta .btn-primary:hover { background: var(--accent); color: var(--accent-fg); }
+@media (max-width: 900px) {
+  .page-head-grid { grid-template-columns: 1fr; }
+  .mo-expertise-grid { grid-template-columns: 1fr; }
+}
 .generic-page li { margin-bottom: var(--space-2); }

--- a/content/en/consulting/_index.md
+++ b/content/en/consulting/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Consulting"
+url: "/consulting"
+layout: "consulting"
+draft: false
+description: "IP advisory for scientists — patent drafting, IP strategy, and workshops for researchers and startups in chemistry and adjacent fields."
+---

--- a/content/pt/consulting/_index.md
+++ b/content/pt/consulting/_index.md
@@ -1,0 +1,7 @@
+---
+title: "Consultoria"
+url: "/pt/consulting/"
+layout: "consulting"
+draft: false
+description: "Consultoria em PI para cientistas — redação de patentes, estratégia de PI e workshops para pesquisadores e startups em química e áreas adjacentes."
+---

--- a/i18n/en.yaml
+++ b/i18n/en.yaml
@@ -8,3 +8,7 @@
   translation: Read more
 - id: translations
   translation: Translations
+- id: consulting
+  translation: Consulting
+- id: subscribe
+  translation: Subscribe

--- a/i18n/pt.yaml
+++ b/i18n/pt.yaml
@@ -8,3 +8,7 @@
   translation: Leia mais
 - id: translations
   translation: Traduções
+- id: consulting
+  translation: Consultoria
+- id: subscribe
+  translation: Inscrever-se

--- a/layouts/_default/consulting.html
+++ b/layouts/_default/consulting.html
@@ -1,0 +1,91 @@
+{{ define "main" }}
+
+{{/* Page header */}}
+<section class="page-head">
+  <div class="container">
+    <div class="page-head-grid">
+      <div>
+        <div class="page-head-eyebrow fade-up">
+          {{ if eq .Site.Language.Lang "pt" }}Consultoria · lançamento 2026{{ else }}Consulting · launching 2026{{ end }}
+        </div>
+        <h1 class="fade-up delay-1">
+          {{ if eq .Site.Language.Lang "pt" }}
+          Consultoria em PI<br>para cientistas.
+          {{ else }}
+          IP advisory<br>for scientists.
+          {{ end }}
+        </h1>
+      </div>
+      <p class="fade-up delay-2">
+        {{ if eq .Site.Language.Lang "pt" }}
+        Uma consultoria boutique para pesquisadores, startups e núcleos de transferência de tecnologia em química e áreas adjacentes.
+        {{ else }}
+        A boutique consultancy for researchers, startups, and technology-transfer offices working in chemistry and adjacent fields.
+        {{ end }}
+      </p>
+    </div>
+  </div>
+</section>
+
+{{/* Services grid */}}
+<section class="mo-expertise">
+  <div class="container">
+    <div class="mo-expertise-grid">
+      <div class="mo-area reveal">
+        <div class="num">→ {{ if eq .Site.Language.Lang "pt" }}SERVIÇO 01{{ else }}SERVICE 01{{ end }}</div>
+        <h3>{{ if eq .Site.Language.Lang "pt" }}Redação de patentes{{ else }}Patent drafting{{ end }}</h3>
+        <p>
+          {{ if eq .Site.Language.Lang "pt" }}
+          Redação ponta-a-ponta de pedidos de patente em química e ciência dos materiais, com ênfase em estratégia de reivindicações e suficiência descritiva.
+          {{ else }}
+          End-to-end drafting of patent applications in chemistry and materials science, with an emphasis on claim strategy and enablement.
+          {{ end }}
+        </p>
+      </div>
+      <div class="mo-area reveal">
+        <div class="num">→ {{ if eq .Site.Language.Lang "pt" }}SERVIÇO 02{{ else }}SERVICE 02{{ end }}</div>
+        <h3>{{ if eq .Site.Language.Lang "pt" }}Estratégia de PI{{ else }}IP strategy{{ end }}</h3>
+        <p>
+          {{ if eq .Site.Language.Lang "pt" }}
+          Análises de patenteabilidade, liberdade de operação, mapeamento tecnológico e revisão de portfólios de PI.
+          {{ else }}
+          Patentability assessments, freedom-to-operate analyses, technology landscaping, and portfolio reviews.
+          {{ end }}
+        </p>
+      </div>
+      <div class="mo-area reveal">
+        <div class="num">→ {{ if eq .Site.Language.Lang "pt" }}SERVIÇO 03{{ else }}SERVICE 03{{ end }}</div>
+        <h3>{{ if eq .Site.Language.Lang "pt" }}Treinamentos{{ else }}Training &amp; workshops{{ end }}</h3>
+        <p>
+          {{ if eq .Site.Language.Lang "pt" }}
+          Workshops para grupos de pesquisa sobre alfabetização em patentes, divulgação de invenções e trajetórias de comercialização.
+          {{ else }}
+          Custom workshops for research groups on patent literacy, invention disclosure, and commercialization pathways.
+          {{ end }}
+        </p>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{/* CTA band */}}
+<section class="mo-cta">
+  <div class="container" style="position:relative;z-index:1">
+    <div class="mo-cta-eyebrow">
+      {{ if eq .Site.Language.Lang "pt" }}Consulte disponibilidade{{ else }}Inquire about engagement{{ end }}
+    </div>
+    <h2>
+      {{ if eq .Site.Language.Lang "pt" }}
+      Abrindo algumas vagas para novos clientes.
+      {{ else }}
+      Taking on a few new clients.
+      {{ end }}
+    </h2>
+    <a href="{{ relLangURL "contact/" }}" class="btn btn-primary"
+       onclick="if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'consulting_contact', location: 'consulting_page' })">
+      {{ if eq .Site.Language.Lang "pt" }}Iniciar uma conversa{{ else }}Start a conversation{{ end }} →
+    </a>
+  </div>
+</section>
+
+{{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,12 +1,15 @@
 {{ define "main" }}
 {{ $section := .Site.GetPage "section" .Section }}
 
+{{/* Reading progress bar */}}
+<div class="read-progress" id="read-progress"></div>
+
 <div class="post-wrap">
 
   {{/* Back link */}}
   <div class="container">
-    <a href="{{ with $section }}{{ .RelPermalink }}{{ else }}/posts/{{ end }}" class="post-back">
-      ← All essays
+    <a href="{{ with $section }}{{ .RelPermalink }}{{ else }}{{ relLangURL "posts/" }}{{ end }}" class="post-back">
+      ← {{ if eq .Site.Language.Lang "pt" }}Todos os ensaios{{ else }}All essays{{ end }}
     </a>
   </div>
 
@@ -43,6 +46,9 @@
     {{ .Content }}
   </article>
 
+  {{/* Inline newsletter CTA — appears after post content */}}
+  {{ partial "newsletter-inline-cta.html" . }}
+
   {{/* Tags */}}
   {{ with .Params.tags }}
   <div class="post-tags container">
@@ -50,11 +56,13 @@
   </div>
   {{ end }}
 
-  {{/* Extras: related posts, buy me a coffee, contact form */}}
+  {{/* End-of-post author + newsletter offer */}}
+  {{ partial "newsletter-end-cta.html" . }}
+
+  {{/* Related posts + buy me a coffee */}}
   <div class="post-extras">
     {{- partial "related-posts.html" . -}}
     {{- partial "buy-me-coffee.html" . -}}
-    {{- partial "form-contact.html" . -}}
   </div>
 
   {{/* Prev / Next */}}
@@ -70,4 +78,22 @@
   </div>
 
 </div>
+
+{{/* Sticky floating newsletter CTA */}}
+{{ partial "sticky-newsletter.html" . }}
+
+{{/* Reading progress bar script */}}
+<script>
+(function () {
+  var bar = document.getElementById('read-progress');
+  if (!bar) return;
+  function update() {
+    var total = document.documentElement.scrollHeight - window.innerHeight;
+    if (total <= 0) return;
+    bar.style.width = Math.min(100, (window.scrollY / total) * 100) + '%';
+  }
+  window.addEventListener('scroll', update, { passive: true });
+  update();
+})();
+</script>
 {{ end }}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,39 +1,63 @@
-{{ define "main" }} {{ $mainSections := .Site.Params.mainSections | default
-(slice "posts") }} {{ $posts := where .Site.RegularPages "Section" "in"
-$mainSections }} {{ $featured := index $posts 0 }} {{ $recent := after 1 (first
-4 $posts) }} {{/* ── Hero ── */}}
+{{ define "main" }}
+{{ $mainSections := .Site.Params.mainSections | default (slice "posts") }}
+{{ $posts := where .Site.RegularPages "Section" "in" $mainSections }}
+{{ $featured := index $posts 0 }}
+{{ $recent := after 1 (first 4 $posts) }}
+
+{{/* ── Hero ── */}}
 <section class="ed-hero">
     <div class="container">
         <div class="ed-hero-grid">
             <div>
                 <div class="ed-hero-eyebrow fade-up">
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Ensaios · Notas · Pesquisa
+                    {{ else }}
                     Analysis · Strategy · Research
+                    {{ end }}
                 </div>
                 <h1 class="fade-up delay-1">
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Um diário sobre <em>química</em>,<br />
+                    propriedade intelectual,<br />
+                    e a arte de <em>construir</em>.
+                    {{ else }}
                     A journal on <em>chemistry</em>,<br />
                     intellectual property,<br />
                     and the craft of <em>building</em>.
+                    {{ end }}
                 </h1>
                 <div class="ed-hero-meta fade-up delay-2">
-                    <div>Written by<strong>Lucas F. Aguiar</strong></div>
-                    <div>Based in<strong>Brasília, Brazil</strong></div>
-                    <div>Essays<strong>{{ len $posts }}</strong></div>
+                    <div>{{ if eq .Site.Language.Lang "pt" }}Por{{ else }}Written by{{ end }}<strong>Lucas F. Aguiar</strong></div>
+                    <div>{{ if eq .Site.Language.Lang "pt" }}Em{{ else }}Based in{{ end }}<strong>{{ if eq .Site.Language.Lang "pt" }}Brasília, Brasil{{ else }}Brasília, Brazil{{ end }}</strong></div>
+                    <div>{{ if eq .Site.Language.Lang "pt" }}Ensaios{{ else }}Essays{{ end }}<strong>{{ len $posts }}</strong></div>
                 </div>
+                {{/* Hero subscribe pill */}}
+                <a href="#newsletter-band" class="ed-hero-pill fade-up delay-3"
+                   onclick="if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'hero_pill' })">
+                    <span class="badge">{{ i18n "subscribe" }}</span>
+                    {{ if eq .Site.Language.Lang "pt" }}Diagnóstico de PI grátis na resposta{{ else }}Free IP read on reply{{ end }}
+                    <span class="arr">→</span>
+                </a>
             </div>
             <div class="ed-hero-aside fade-up delay-2">
                 <span class="quote-mark">"</span>
-                The best way I know to understand something is to try to explain
-                it — to students, to clients, to myself, six months later.
+                {{ if eq .Site.Language.Lang "pt" }}
+                A melhor maneira que conheço de entender algo é tentar explicá-lo — a alunos, a clientes, a mim mesmo, seis meses depois.
+                {{ else }}
+                The best way I know to understand something is to try to explain it — to students, to clients, to myself, six months later.
+                {{ end }}
             </div>
         </div>
     </div>
 </section>
 
-{{/* ── Featured post ── */}} {{ with $featured }}
+{{/* ── Featured post ── */}}
+{{ with $featured }}
 <section class="ed-featured">
     <div class="container">
         <div class="ed-featured-label">
-            <span class="mono-label">The Lead Essay</span>
+            <span class="mono-label">{{ if eq $.Site.Language.Lang "pt" }}Ensaio Principal{{ else }}The Lead Essay{{ end }}</span>
             <hr />
             <span class="mono-label">№ 001</span>
         </div>
@@ -42,7 +66,7 @@ $mainSections }} {{ $featured := index $posts 0 }} {{ $recent := after 1 (first
                 {{ with .Params.featured_image }}
                 <img src="{{ . }}" alt="{{ $.Title }}" />
                 {{ else }}
-                <div class="img-placeholder">Featured illustration</div>
+                <div class="img-placeholder">{{ if eq $.Site.Language.Lang "pt" }}Ilustração principal{{ else }}Featured illustration{{ end }}</div>
                 {{ end }}
             </a>
             <div>
@@ -52,25 +76,24 @@ $mainSections }} {{ $featured := index $posts 0 }} {{ $recent := after 1 (first
                 <h2><a href="{{ .RelPermalink }}">{{ .Title }}</a></h2>
                 <p>{{ .Summary | truncate 200 }}</p>
                 <div class="ed-byline">
-                    <span
-                        >{{ .Site.Params.author | default "Lucas Aguiar"
-                        }}</span
-                    >
+                    <span>{{ .Site.Params.author | default "Lucas Aguiar" }}</span>
                     <span class="dot"></span>
                     <span>{{ .Date.Format "Jan 2, 2006" }}</span>
-                    {{ if .ReadingTime }}<span class="dot"></span
-                    ><span>{{ .ReadingTime }} min read</span>{{ end }}
+                    {{ if .ReadingTime }}<span class="dot"></span><span>{{ .ReadingTime }} min {{ if eq $.Site.Language.Lang "pt" }}de leitura{{ else }}read{{ end }}</span>{{ end }}
                 </div>
             </div>
         </div>
     </div>
 </section>
-{{ end }} {{/* ── Recent posts grid ── */}} {{ if $recent }}
+{{ end }}
+
+{{/* ── Recent posts grid ── */}}
+{{ if $recent }}
 <section class="ed-grid">
     <div class="container">
         <div class="ed-grid-head">
-            <h2>Recent writing</h2>
-            <a href="/posts/" class="btn-link">All essays</a>
+            <h2>{{ if eq .Site.Language.Lang "pt" }}Textos recentes{{ else }}Recent writing{{ end }}</h2>
+            <a href="{{ relLangURL "posts/" }}" class="btn-link">{{ if eq .Site.Language.Lang "pt" }}Todos os ensaios{{ else }}All essays{{ end }}</a>
         </div>
         <div class="ed-grid-posts">
             {{ range $i, $p := $recent }}
@@ -85,22 +108,26 @@ $mainSections }} {{ $featured := index $posts 0 }} {{ $recent := after 1 (first
                 <h3><a href="{{ $p.RelPermalink }}">{{ $p.Title }}</a></h3>
                 <p>{{ $p.Summary | truncate 120 }}</p>
                 <div class="ed-post-meta">
-                    {{ $p.Date.Format "Jan 2, 2006" }}{{ if $p.ReadingTime }} ·
-                    {{ $p.ReadingTime }} min{{ end }}
+                    {{ $p.Date.Format "Jan 2, 2006" }}{{ if $p.ReadingTime }} · {{ $p.ReadingTime }} min{{ end }}
                 </div>
             </article>
             {{ end }}
         </div>
     </div>
 </section>
-{{ end }} {{/* ── Pull quote ── */}}
+{{ end }}
+
+{{/* ── Pull quote ── */}}
 <section class="ed-pull reveal">
     <div class="container">
         <blockquote>
-            "Patents are the technical literature of the future. To draft one
-            well is to <em>commit a possibility</em> to record."
+            {{ if eq .Site.Language.Lang "pt" }}
+            "Patentes são a literatura técnica do futuro. Redigir uma bem é <em>comprometer uma possibilidade</em> ao registro."
+            {{ else }}
+            "Patents are the technical literature of the future. To draft one well is to <em>commit a possibility</em> to record."
+            {{ end }}
         </blockquote>
-        <cite>From the about page</cite>
+        <cite>{{ if eq .Site.Language.Lang "pt" }}Da página sobre{{ else }}From the about page{{ end }}</cite>
     </div>
 </section>
 
@@ -108,69 +135,106 @@ $mainSections }} {{ $featured := index $posts 0 }} {{ $recent := after 1 (first
 <section class="ed-work reveal">
     <div class="container">
         <div class="ed-work-head">
-            <h2>What I work on</h2>
-            <span class="mono-label">Four practice areas</span>
+            <h2>{{ if eq .Site.Language.Lang "pt" }}Minhas áreas{{ else }}What I work on{{ end }}</h2>
+            <span class="mono-label">{{ if eq .Site.Language.Lang "pt" }}Quatro áreas de atuação{{ else }}Four practice areas{{ end }}</span>
         </div>
         <div class="ed-work-grid">
             <div class="ed-work-item">
                 <span class="num">01</span>
-                <h3>Patent Prosecution</h3>
+                <h3>{{ if eq .Site.Language.Lang "pt" }}Redação de Patentes{{ else }}Patent Prosecution{{ end }}</h3>
                 <p>
-                    Drafting and prosecuting applications in chemistry,
-                    materials science and pharmaceuticals.
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Redação e acompanhamento de pedidos em química, ciência dos materiais e farmacêutica.
+                    {{ else }}
+                    Drafting and prosecuting applications in chemistry, materials science and pharmaceuticals.
+                    {{ end }}
                 </p>
             </div>
             <div class="ed-work-item">
                 <span class="num">02</span>
-                <h3>IP Consulting</h3>
+                <h3>{{ if eq .Site.Language.Lang "pt" }}Consultoria em PI{{ else }}IP Consulting{{ end }}</h3>
                 <p>
-                    Strategy, patentability assessments, and commercialization
-                    pathways.
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Estratégia, análises de patenteabilidade e trajetórias de comercialização.
+                    {{ else }}
+                    Strategy, patentability assessments, and commercialization pathways.
+                    {{ end }}
                 </p>
             </div>
             <div class="ed-work-item">
                 <span class="num">03</span>
-                <h3>Research and Development</h3>
+                <h3>{{ if eq .Site.Language.Lang "pt" }}Pesquisa e Desenvolvimento{{ else }}Research and Development{{ end }}</h3>
                 <p>
-                    PhD work in topics around carbon capture, such as
-                    freeze-casting, dense membranes, and commercial systems at
-                    LMCNano/UnB.
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Doutorado em fotovoltaicos de perovskita, membranas de separação de gases e captura de carbono no LMCNano/UnB.
+                    {{ else }}
+                    PhD work on perovskite solar cells, gas separation membranes, and carbon capture at LMCNano/UnB.
+                    {{ end }}
                 </p>
             </div>
             <div class="ed-work-item">
                 <span class="num">04</span>
-                <h3>Writing &amp; Teaching</h3>
+                <h3>{{ if eq .Site.Language.Lang "pt" }}Escrita &amp; Ensino{{ else }}Writing &amp; Teaching{{ end }}</h3>
                 <p>
-                    Essays and guest lectures on innovation and IP education and
-                    strategies.
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Ensaios e palestras sobre inovação, PI e como a IA transforma o trabalho técnico.
+                    {{ else }}
+                    Essays and guest lectures on innovation, IP education, and how AI transforms technical work.
+                    {{ end }}
                 </p>
             </div>
         </div>
     </div>
 </section>
 
-{{/* ── Newsletter / contact CTA ── */}}
-<section class="ed-newsletter reveal">
+{{/* ── Newsletter band (primary CTA) ── */}}
+<section class="ed-newsletter reveal" id="newsletter-band">
     <div class="container">
         <div class="ed-newsletter-inner">
             <div>
-                <h2>Get in touch.</h2>
+                <div class="ed-hero-eyebrow" style="margin-bottom:16px">
+                    {{ if eq .Site.Language.Lang "pt" }}A Newsletter · Grátis{{ else }}The Newsletter · Free{{ end }}
+                </div>
+                <h2>
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Uma carta, uma vez por mês <em style="color:var(--accent);font-style:italic">+ uma análise de PI grátis</em> sobre o que você responder.
+                    {{ else }}
+                    A letter, once a month <em style="color:var(--accent);font-style:italic">+ a free IP read</em> on what you reply with.
+                    {{ end }}
+                </h2>
                 <p>
-                    Whether it's a patent question, a speaking invitation, or
-                    just a note — I read everything and respond to most within a
-                    few days.
+                    {{ if eq .Site.Language.Lang "pt" }}
+                    Inscreva-se e responda ao email de boas-vindas com o que você está desenvolvendo. Devolvo uma análise curta e honesta — ângulo de patenteabilidade, anterioridade, por onde começar. De um redator de patentes e consultor em PI do Ministério da Saúde.
+                    {{ else }}
+                    Subscribe and reply to the welcome email with what you're working on. I'll send back a short, honest take — patentability angle, prior art notes, where to start. From a working patent prosecutor and IP consultant for Brazil's Ministry of Health.
+                    {{ end }}
                 </p>
             </div>
             <div>
-                <a href="/contact/" class="btn btn-primary" onclick="if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { location: 'home_page' })"
-                    >Start a conversation →</a
-                >
-                <div class="ed-form-note" style="margin-top: 16px">
-                    Patent drafting · IP strategy · Collaboration
+                <div class="ed-form-row">
+                    <input type="email" id="home-newsletter-email" placeholder="{{ if eq .Site.Language.Lang "pt" }}seu@email.com{{ else }}your@email.com{{ end }}" required>
+                    <button type="button" onclick="
+                      var email = document.getElementById('home-newsletter-email').value;
+                      if (!email || !email.includes('@')) return;
+                      if (typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'home_newsletter', email: email });
+                      this.closest('.ed-newsletter').querySelector('.ed-newsletter-success').classList.add('show');
+                      this.closest('.ed-form-row').style.display='none';
+                    ">
+                        {{ i18n "subscribe" }} →
+                    </button>
+                </div>
+                <div class="ed-newsletter-success">
+                    {{ if eq .Site.Language.Lang "pt" }}✓ INSCRITO · verifique sua caixa de entrada{{ else }}✓ SUBSCRIBED · check your inbox{{ end }}
+                </div>
+                <div class="ed-newsletter-deliverables">
+                    <span class="ed-newsletter-deliv">{{ if eq .Site.Language.Lang "pt" }}Análise grátis na resposta{{ else }}Free IP read on reply{{ end }}</span>
+                    <span class="ed-newsletter-deliv">{{ if eq .Site.Language.Lang "pt" }}Mensal · sem spam{{ else }}Monthly · no spam{{ end }}</span>
+                    <span class="ed-newsletter-deliv">{{ if eq .Site.Language.Lang "pt" }}1 clique para sair{{ else }}1-click unsubscribe{{ end }}</span>
                 </div>
             </div>
         </div>
     </div>
 </section>
 
-{{ partial "buy-me-coffee.html" . }} {{ end }}
+{{ partial "buy-me-coffee.html" . }}
+{{ end }}

--- a/layouts/partials/newsletter-end-cta.html
+++ b/layouts/partials/newsletter-end-cta.html
@@ -1,0 +1,73 @@
+{{/* End-of-post author + newsletter offer block */}}
+<div class="post-end-cta">
+  <div class="post-end-cta-grid">
+    <div>
+      <div class="post-end-avatar">
+        <img src="https://lucasaguiarxyzstorage.blob.core.windows.net/images/lucas-perfil-2022.jpg" alt="Lucas Aguiar">
+      </div>
+    </div>
+    <div>
+      <div class="post-end-eyebrow">
+        {{ if eq .Site.Language.Lang "pt" }}Sobre o autor{{ else }}About the author{{ end }}
+      </div>
+      <h3>
+        {{ if eq .Site.Language.Lang "pt" }}
+          Receba uma <em>análise de PI grátis</em> sobre o que você está desenvolvendo.
+        {{ else }}
+          Get a <em>free IP read</em> on what you're building.
+        {{ end }}
+      </h3>
+      <p class="post-end-bio">
+        {{ if eq .Site.Language.Lang "pt" }}
+          Sou Lucas Aguiar — químico, redator de patentes e consultor técnico em PI do Ministério da Saúde. Inscreva-se na newsletter e responda ao email de boas-vindas com o que você está desenvolvendo: devolvo uma análise curta e honesta sobre patenteabilidade, anterioridade ou por onde começar.
+        {{ else }}
+          I'm Lucas Aguiar — chemist, patent prosecutor, and technical IP consultant for Brazil's Ministry of Health. Subscribe to the newsletter and reply to the welcome email with what you're building: I'll send back a short, honest take — patentability angle, prior art notes, where to start.
+        {{ end }}
+      </p>
+      <div class="post-end-creds">
+        {{ if eq .Site.Language.Lang "pt" }}
+          <span class="post-end-cred">Doutorando, UnB</span>
+          <span class="post-end-cred">Consultor em PI · Ministério da Saúde</span>
+          <span class="post-end-cred">Redator de patentes · 8+ anos</span>
+          <span class="post-end-cred">Química · Materiais · Farmacêutica</span>
+        {{ else }}
+          <span class="post-end-cred">PhD Candidate, UnB</span>
+          <span class="post-end-cred">IP Consultant · Ministry of Health</span>
+          <span class="post-end-cred">Patent Prosecutor · 8+ years</span>
+          <span class="post-end-cred">Chemistry · Materials · Pharma</span>
+        {{ end }}
+      </div>
+      <div class="post-end-offer">
+        <input type="email" id="end-cta-email" placeholder="{{ if eq .Site.Language.Lang "pt" }}seu@email.com{{ else }}your@email.com{{ end }}" required>
+        <button type="button" onclick="
+          var email = document.getElementById('end-cta-email').value;
+          if (!email || !email.includes('@')) return;
+          if (typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'post_end', email: email });
+          this.closest('.post-end-offer').style.display='none';
+          this.closest('.post-end-cta').querySelector('.post-end-end-success').classList.add('show');
+        ">
+          {{ if eq .Site.Language.Lang "pt" }}Inscrever-se{{ else }}Subscribe{{ end }} →
+        </button>
+      </div>
+      <div class="post-end-end-success">
+        <strong>{{ if eq .Site.Language.Lang "pt" }}✓ INSCRITO{{ else }}✓ SUBSCRIBED{{ end }}</strong>
+        {{ if eq .Site.Language.Lang "pt" }}
+          Obrigado! Verifique seu email e responda com o que você está desenvolvendo — respondo em alguns dias.
+        {{ else }}
+          Thank you! Check your inbox and reply with what you're building — I'll respond within a few days.
+        {{ end }}
+      </div>
+      <div class="post-end-micro">
+        {{ if eq .Site.Language.Lang "pt" }}
+          <span>Mensal · sem spam</span>
+          <span>Análise grátis na resposta</span>
+          <span>1 clique para sair</span>
+        {{ else }}
+          <span>Monthly · no spam</span>
+          <span>Free IP read on reply</span>
+          <span>1-click unsubscribe</span>
+        {{ end }}
+      </div>
+    </div>
+  </div>
+</div>

--- a/layouts/partials/newsletter-inline-cta.html
+++ b/layouts/partials/newsletter-inline-cta.html
@@ -1,0 +1,36 @@
+{{/* Inline mid-post newsletter break */}}
+<div class="post-inline-cta">
+  <div class="label">{{ i18n "subscribe" }} · {{ if eq .Site.Language.Lang "pt" }}Grátis{{ else }}Free{{ end }}</div>
+  <h4>
+    {{ if eq .Site.Language.Lang "pt" }}
+      Uma carta mensal <em style="color:var(--accent)">+ uma análise de PI grátis</em> para você.
+    {{ else }}
+      A monthly letter <em style="color:var(--accent)">+ a free IP read</em> just for you.
+    {{ end }}
+  </h4>
+  <p>
+    {{ if eq .Site.Language.Lang "pt" }}
+      Inscreva-se e responda ao email de boas-vindas com o que você está desenvolvendo. Devolvo uma análise curta e honesta sobre patenteabilidade ou anterioridade.
+    {{ else }}
+      Subscribe and reply to the welcome email with what you're working on. I'll send back a short, honest take on patentability or prior art.
+    {{ end }}
+  </p>
+  <div class="ic-form">
+    <input type="email" id="inline-cta-email" placeholder="{{ if eq .Site.Language.Lang "pt" }}seu@email.com{{ else }}your@email.com{{ end }}" required>
+    <button type="button" onclick="
+      var email = document.getElementById('inline-cta-email').value;
+      if (!email || !email.includes('@')) return;
+      if (typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'post_inline', email: email });
+      this.closest('.post-inline-cta').querySelector('.ic-form').style.display='none';
+      this.closest('.post-inline-cta').querySelector('.post-inline-success').classList.add('show');
+    ">
+      {{ if eq .Site.Language.Lang "pt" }}Inscrever-se{{ else }}Subscribe{{ end }} →
+    </button>
+  </div>
+  <div class="post-inline-success">
+    {{ if eq .Site.Language.Lang "pt" }}✓ Inscrito · verifique sua caixa de entrada{{ else }}✓ Subscribed · check your inbox{{ end }}
+  </div>
+  <div class="micro">
+    {{ if eq .Site.Language.Lang "pt" }}Mensal · sem spam · 1 clique para sair{{ else }}Monthly · no spam · 1-click unsubscribe{{ end }}
+  </div>
+</div>

--- a/layouts/partials/site-footer.html
+++ b/layouts/partials/site-footer.html
@@ -35,18 +35,19 @@
 
       <div class="footer-col">
         <h4>Site</h4>
-        <a href="{{ .Site.Home.RelPermalink }}">Home</a>
-        <a href="/posts/">Blog</a>
-        <a href="/about/">About</a>
-        <a href="/contact/">Contact</a>
+        <a href="{{ .Site.Home.RelPermalink }}">{{ if eq .Site.Language.Lang "pt" }}Início{{ else }}Home{{ end }}</a>
+        <a href="{{ relLangURL "posts/" }}">Blog</a>
+        <a href="{{ relLangURL "about/" }}">{{ i18n "about" }}</a>
+        <a href="{{ relLangURL "consulting/" }}">{{ i18n "consulting" }}</a>
+        <a href="{{ relLangURL "contact/" }}">{{ i18n "contact" }}</a>
       </div>
 
       <div class="footer-col">
-        <h4>Practice</h4>
-        <a href="/about/">Patent Prosecution</a>
-        <a href="/about/">IP Consulting</a>
-        <a href="/about/">Research</a>
-        <a href="/about/">PhD Work</a>
+        <h4>{{ if eq .Site.Language.Lang "pt" }}Prática{{ else }}Practice{{ end }}</h4>
+        <a href="{{ relLangURL "consulting/" }}">{{ if eq .Site.Language.Lang "pt" }}Redação de Patentes{{ else }}Patent Prosecution{{ end }}</a>
+        <a href="{{ relLangURL "consulting/" }}">{{ if eq .Site.Language.Lang "pt" }}Consultoria em PI{{ else }}IP Consulting{{ end }}</a>
+        <a href="{{ relLangURL "about/" }}">{{ if eq .Site.Language.Lang "pt" }}Pesquisa{{ else }}Research{{ end }}</a>
+        <a href="{{ relLangURL "about/" }}">{{ if eq .Site.Language.Lang "pt" }}Doutorado{{ else }}PhD Work{{ end }}</a>
       </div>
 
       <div class="footer-col">

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -11,6 +11,7 @@
         <div class="nav-links">
           <a href="{{ relLangURL "posts/" }}"{{ if eq .Section "posts" }} class="active"{{ end }}>Blog</a>
           <a href="{{ relLangURL "about/" }}"{{ if strings.HasSuffix .RelPermalink "about/" }} class="active"{{ end }}>{{ i18n "about" }}</a>
+          <a href="{{ relLangURL "consulting/" }}"{{ if strings.HasSuffix .RelPermalink "consulting/" }} class="active"{{ end }}>{{ i18n "consulting" }}</a>
           <a href="{{ relLangURL "contact/" }}"{{ if strings.HasSuffix .RelPermalink "contact/" }} class="active"{{ end }} onclick="if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { location: 'header_nav' })">{{ i18n "contact" }}</a>
         </div>
         <div class="nav-ctrls">
@@ -33,6 +34,10 @@
           <button class="nav-menu-btn" id="nav-menu-btn" aria-label="Open menu">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
           </button>
+          <a href="#newsletter-band" class="nav-cta" onclick="if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'nav_pill' }); var nb=document.getElementById('newsletter-band'); if(nb){event.preventDefault();nb.scrollIntoView({behavior:'smooth'});}">
+            <span class="glyph"></span>
+            {{ i18n "subscribe" }}
+          </a>
         </div>
       </div>
     </div>
@@ -41,6 +46,7 @@
     <div class="nav-mobile" id="nav-mobile">
       <a href="{{ relLangURL "posts/" }}"{{ if eq .Section "posts" }} style="color:var(--fg)"{{ end }}>Blog</a>
       <a href="{{ relLangURL "about/" }}"{{ if strings.HasSuffix .RelPermalink "about/" }} style="color:var(--fg)"{{ end }}>{{ i18n "about" }}</a>
+      <a href="{{ relLangURL "consulting/" }}"{{ if strings.HasSuffix .RelPermalink "consulting/" }} style="color:var(--fg)"{{ end }}>{{ i18n "consulting" }}</a>
       <a href="{{ relLangURL "contact/" }}"{{ if strings.HasSuffix .RelPermalink "contact/" }} style="color:var(--fg)"{{ end }} onclick="if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { location: 'mobile_nav' })">{{ i18n "contact" }}</a>
     </div>
   </div>

--- a/layouts/partials/sticky-newsletter.html
+++ b/layouts/partials/sticky-newsletter.html
@@ -1,0 +1,72 @@
+{{/* Sticky bottom-left newsletter CTA — appears after 25% scroll, dismissable */}}
+<div class="sticky-cta" id="sticky-cta" aria-live="polite">
+  <button class="sticky-cta-close" id="sticky-cta-close" aria-label="Dismiss">✕</button>
+  <div class="sticky-cta-eyebrow">
+    <span class="live"></span>
+    {{ if eq .Site.Language.Lang "pt" }}Newsletter · Grátis{{ else }}Newsletter · Free{{ end }}
+  </div>
+  <div class="sticky-cta-title">
+    {{ if eq .Site.Language.Lang "pt" }}
+      Diagnóstico de PI grátis quando você responder.
+    {{ else }}
+      Free IP read when you reply.
+    {{ end }}
+  </div>
+  <div class="sticky-cta-desc">
+    {{ if eq .Site.Language.Lang "pt" }}
+      Uma carta mensal de um redator de patentes e consultor em PI do Ministério da Saúde.
+    {{ else }}
+      A monthly letter from a patent prosecutor and IP consultant at Brazil's Ministry of Health.
+    {{ end }}
+  </div>
+  <div class="sticky-cta-form">
+    <input type="email" id="sticky-cta-email" placeholder="{{ if eq .Site.Language.Lang "pt" }}seu@email.com{{ else }}your@email.com{{ end }}" required>
+    <button type="button" id="sticky-cta-submit">
+      {{ if eq .Site.Language.Lang "pt" }}Entrar{{ else }}Join{{ end }}
+    </button>
+  </div>
+  <div class="sticky-cta-success" id="sticky-cta-success">
+    {{ if eq .Site.Language.Lang "pt" }}✓ INSCRITO · verifique sua caixa de entrada{{ else }}✓ SUBSCRIBED · check your inbox{{ end }}
+  </div>
+  <div class="sticky-cta-micro">
+    {{ if eq .Site.Language.Lang "pt" }}Mensal · sem spam · 1 clique para sair{{ else }}Monthly · no spam · 1-click unsubscribe{{ end }}
+  </div>
+</div>
+
+<script>
+(function () {
+  var KEY = 'sticky_cta_closed';
+  var cta = document.getElementById('sticky-cta');
+  if (!cta) return;
+  if (sessionStorage.getItem(KEY)) return;
+
+  var shown = false;
+  function show() {
+    if (shown) return;
+    shown = true;
+    cta.classList.add('visible');
+    if (typeof posthog !== 'undefined') posthog.capture('sticky_cta_shown');
+  }
+
+  function onScroll() {
+    var pct = window.scrollY / (document.documentElement.scrollHeight - window.innerHeight);
+    if (pct >= 0.25) show();
+  }
+  window.addEventListener('scroll', onScroll, { passive: true });
+
+  document.getElementById('sticky-cta-close').addEventListener('click', function () {
+    cta.classList.remove('visible');
+    sessionStorage.setItem(KEY, '1');
+    if (typeof posthog !== 'undefined') posthog.capture('sticky_cta_dismissed');
+  });
+
+  document.getElementById('sticky-cta-submit').addEventListener('click', function () {
+    var email = document.getElementById('sticky-cta-email').value;
+    if (!email || !email.includes('@')) return;
+    if (typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'sticky_cta', email: email });
+    document.querySelector('.sticky-cta-form').style.display = 'none';
+    document.getElementById('sticky-cta-success').classList.add('show');
+    sessionStorage.setItem(KEY, '1');
+  });
+})();
+</script>


### PR DESCRIPTION
…og tracking

Implements the v2 design handoff to increase newsletter signups and contact conversions, applied to both EN and PT site languages.

Changes:
- Subscribe pill in nav (desktop, hidden on mobile)
- Hero subscribe pill linking to newsletter band
- Upgraded newsletter band on homepage with offer copy, email form, and deliverables list (free IP read on reply · monthly · 1-click unsubscribe)
- Inline mid-post newsletter CTA after article content
- End-of-post author block: bio, credentials, and newsletter offer form
- Sticky bottom-left newsletter card (appears at 25% scroll, sessionStorage dismiss)
- Reading progress bar (2px accent line at top of viewport) on single posts
- New Consulting/Consultoria page (EN: /consulting/, PT: /pt/consulting/) with 3-service grid and contact CTA band
- Consulting link added to desktop nav, mobile nav, and footer in both languages
- PostHog cta_clicked events on all subscribe buttons with location context: hero_pill, nav_pill, home_newsletter, post_inline, post_end, sticky_cta
- i18n keys: consulting and subscribe in EN + PT
- All changes fully bilingual (EN/PT via site.Language.Lang checks)

Newsletter form is UI-only for now (PostHog fires on submit, success state shown); wire up a service endpoint when ready.