### PR TITLE
feat: add dedicated /newsletter page and fix nav CTA on non-home pages

### DIFF
--- a/content/en/newsletter/_index.md
+++ b/content/en/newsletter/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Newsletter"
+description: "A monthly letter on IP and chemistry research — plus a free IP read just for you."
+layout: "newsletter"
+---

--- a/content/pt/newsletter/_index.md
+++ b/content/pt/newsletter/_index.md
@@ -1,0 +1,5 @@
+---
+title: "Newsletter"
+description: "Uma carta mensal sobre PI e pesquisa em química — mais uma análise de PI grátis para você."
+layout: "newsletter"
+---

--- a/layouts/_default/newsletter.html
+++ b/layouts/_default/newsletter.html
@@ -1,0 +1,79 @@
+{{ define "main" }}
+
+{{/* Page header */}}
+<section class="page-head">
+  <div class="container">
+    <div class="page-head-grid">
+      <div>
+        <div class="page-head-eyebrow fade-up">
+          {{ if eq .Site.Language.Lang "pt" }}Newsletter · Grátis{{ else }}Newsletter · Free{{ end }}
+        </div>
+        <h1 class="fade-up delay-1">
+          {{ if eq .Site.Language.Lang "pt" }}
+          Uma carta mensal<br><em style="color:var(--accent)">+ uma análise de PI grátis.</em>
+          {{ else }}
+          A monthly letter<br><em style="color:var(--accent)">+ a free IP read.</em>
+          {{ end }}
+        </h1>
+      </div>
+      <p class="fade-up delay-2">
+        {{ if eq .Site.Language.Lang "pt" }}
+        Inscreva-se e responda ao email de boas-vindas com o que você está desenvolvendo. Devolvo uma análise curta e honesta — ângulo de patenteabilidade, anterioridade, por onde começar. De um redator de patentes e consultor em PI do Ministério da Saúde.
+        {{ else }}
+        Subscribe and reply to the welcome email with what you're working on. I'll send back a short, honest take — patentability angle, prior art notes, where to start. From a working patent prosecutor and IP consultant for Brazil's Ministry of Health.
+        {{ end }}
+      </p>
+    </div>
+  </div>
+</section>
+
+{{/* Newsletter form */}}
+<section class="ed-newsletter reveal" id="newsletter-band" style="margin-top:0">
+  <div class="container">
+    <div class="ed-newsletter-inner">
+      <div>
+        <div class="ed-hero-eyebrow" style="margin-bottom:16px">
+          {{ if eq .Site.Language.Lang "pt" }}O que você recebe{{ else }}What you get{{ end }}
+        </div>
+        <h2>
+          {{ if eq .Site.Language.Lang "pt" }}
+          Uma carta, uma vez por mês <em style="color:var(--accent);font-style:italic">+ uma análise de PI grátis</em> sobre o que você responder.
+          {{ else }}
+          A letter, once a month <em style="color:var(--accent);font-style:italic">+ a free IP read</em> on what you reply with.
+          {{ end }}
+        </h2>
+        <p>
+          {{ if eq .Site.Language.Lang "pt" }}
+          Mensal, sem spam. Cancele com 1 clique a qualquer momento.
+          {{ else }}
+          Monthly, no spam. Cancel with 1 click at any time.
+          {{ end }}
+        </p>
+      </div>
+      <div>
+        <div class="ed-form-row">
+          <input type="email" id="newsletter-page-email" placeholder="{{ if eq .Site.Language.Lang "pt" }}seu@email.com{{ else }}your@email.com{{ end }}" required>
+          <button type="button" onclick="
+            var email = document.getElementById('newsletter-page-email').value;
+            if (!email || !email.includes('@')) return;
+            if (typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'newsletter_page', email: email });
+            this.closest('.ed-newsletter').querySelector('.ed-newsletter-success').classList.add('show');
+            this.closest('.ed-form-row').style.display='none';
+          ">
+            {{ i18n "subscribe" }} →
+          </button>
+        </div>
+        <div class="ed-newsletter-success">
+          {{ if eq .Site.Language.Lang "pt" }}✓ INSCRITO · verifique sua caixa de entrada{{ else }}✓ SUBSCRIBED · check your inbox{{ end }}
+        </div>
+        <div class="ed-newsletter-deliverables">
+          <span class="ed-newsletter-deliv">{{ if eq .Site.Language.Lang "pt" }}Análise grátis na resposta{{ else }}Free IP read on reply{{ end }}</span>
+          <span class="ed-newsletter-deliv">{{ if eq .Site.Language.Lang "pt" }}Mensal · sem spam{{ else }}Monthly · no spam{{ end }}</span>
+          <span class="ed-newsletter-deliv">{{ if eq .Site.Language.Lang "pt" }}1 clique para sair{{ else }}1-click unsubscribe{{ end }}</span>
+        </div>
+      </div>
+    </div>
+  </div>
+</section>
+
+{{ end }}

--- a/layouts/partials/site-header.html
+++ b/layouts/partials/site-header.html
@@ -34,7 +34,7 @@
           <button class="nav-menu-btn" id="nav-menu-btn" aria-label="Open menu">
             <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M3 12h18M3 6h18M3 18h18"/></svg>
           </button>
-          <a href="#newsletter-band" class="nav-cta" onclick="if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'nav_pill' }); var nb=document.getElementById('newsletter-band'); if(nb){event.preventDefault();nb.scrollIntoView({behavior:'smooth'});}">
+          <a href="{{ relLangURL "newsletter/" }}" class="nav-cta" onclick="var nb=document.getElementById('newsletter-band'); if(nb){event.preventDefault();nb.scrollIntoView({behavior:'smooth'});} if(typeof posthog !== 'undefined') posthog.capture('cta_clicked', { cta_name: 'newsletter_subscribe', location: 'nav_pill' });">
             <span class="glyph"></span>
             {{ i18n "subscribe" }}
           </a>


### PR DESCRIPTION
The subscribe button in the nav used href="#newsletter-band" with a JS scroll-to handler that only worked on the home page (the only page with that element). On all other pages, getElementById returned null, the event.preventDefault() was never called, and the browser just appended the anchor to the current URL — nothing visible happened.

Fix: update the nav CTA href to relLangURL "newsletter/" so it navigates to the new dedicated page on any non-home page, while preserving the smooth-scroll behavior on the home page (where #newsletter-band exists).

New files:
- layouts/_default/newsletter.html — standalone page with hero + form
- content/en/newsletter/_index.md — route /newsletter/
- content/pt/newsletter/_index.md — route /pt/newsletter/