### PR TITLE
ci: chain translate workflow to run after backlinks completes

### DIFF
--- a/.github/workflows/auto-translate.yaml
+++ b/.github/workflows/auto-translate.yaml
@@ -4,14 +4,17 @@ env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 on:
+  workflow_run:
+    workflows: ["Auto Suggest Backlinks"]
+    types: [completed]
   push:
     paths:
-      - 'content/**/*.md'
       - 'scripts/translate.js'
 
 jobs:
   translate:
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' || github.event_name == 'push' }}
     permissions:
       contents: write
     


### PR DESCRIPTION
Both workflows were triggering in parallel on push to content/**/*.md, causing translate to run before backlinks committed its changes and triggering a second redundant translate run after backlinks pushed.

Now auto-translate triggers via workflow_run after Auto Suggest Backlinks completes successfully, ensuring the correct order and a single execution.