### PR TITLE
fix: prioritize missing translations and exclude _index.md from backlinks

### DIFF
--- a/content/en/posts/ai-powered-protein-sequencing.md
+++ b/content/en/posts/ai-powered-protein-sequencing.md
@@ -398,7 +398,7 @@ The technology is still in its early stages, and its full potential remains to b
 
 Read also:
 
-- [From Developers to Scientists: How AI Is Transforming the Complexity of Code]({{< relref "posts/ia-desenvolvimento-software-complexidade-codigo/" >}})
+- [From Developers to Scientists: How AI Is Transforming Code Complexity]({{< relref "posts/ia-desenvolvimento-software-complexidade-codigo/" >}})
 - [The INPI backlog is over — but not for drug patents]({{< relref "posts/backlog-inpi-patentes-farmaceuticas/" >}})
 - [Inside AI Brains: How Anthropic Decoded Claude's Thinking Process]({{< relref "posts/anthropic-thinking-process-paper/" >}})
 

--- a/content/en/posts/hugo-content-file-structure.md
+++ b/content/en/posts/hugo-content-file-structure.md
@@ -54,7 +54,7 @@ My references for this is all over the place, but here they are:
 
 Read also:
 
-- [Complete Guide: How to Integrate Beehiiv with Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
+- [Complete Guide: How to Integrate Beehiiv to Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
 - [Using Oracle Cloud Free tier]({{< relref "posts/oracle_cloud_vps/" >}})
 - [Introduction to my new space on the internet]({{< relref "posts/introduction/" >}})
 

--- a/content/en/posts/ia-desenvolvimento-software-complexidade-codigo.md
+++ b/content/en/posts/ia-desenvolvimento-software-complexidade-codigo.md
@@ -55,9 +55,9 @@ Artificial intelligence has been a topic of interest for me, and I have already 
 
 Read also:
 
-- [The AI Copy-Paste Problem: Killing Software Lock-in & Why Data Portability Is Crucial]({{< relref "posts/ai-copy-paste-problem/" >}})
+- [The AI Copy-Paste Problem: Killing Software Lock-In & Why Data Portability is Key]({{< relref "posts/ai-copy-paste-problem/" >}})
 - [From Cursor to Windsurf to Zed: My Journey Through AI-Enhanced Code Editors]({{< relref "posts/experience-with-cursor-and-windsurf/" >}})
-- [Why I'm Breaking Up with Vibe Coding]({{< relref "posts/vibe-coding-pitfalls/" >}})
+- [Why I'm Breaking Up With Vibe Coding]({{< relref "posts/vibe-coding-pitfalls/" >}})
 
 ---
 

--- a/content/en/posts/newsletter-beehiiv-cloudflare-github.md
+++ b/content/en/posts/newsletter-beehiiv-cloudflare-github.md
@@ -244,8 +244,8 @@ I hope this guide has clarified the architecture for creating a robust and invis
 
 Read also:
 
-- [Using the Oracle Cloud Free Tier]({{< relref "posts/oracle_cloud_vps/" >}})
-- [Fixing Proxmox Web Interface Login Errors: Step-by-Step Guide]({{< relref "posts/troubleshooting-proxmox-login-interface/" >}})
+- [Using Oracle Cloud Free tier]({{< relref "posts/oracle_cloud_vps/" >}})
+- [Fix Proxmox Web Interface Login Errors; a Step-by-Step Guide]({{< relref "posts/troubleshooting-proxmox-login-interface/" >}})
 - [Hugo Content File Structure]({{< relref "posts/hugo-content-file-structure/" >}})
 
 ---

--- a/content/en/posts/oracle_cloud_vps.md
+++ b/content/en/posts/oracle_cloud_vps.md
@@ -75,7 +75,7 @@ I hope this article was useful to some of you who are trying to expose some inte
 
 Read also:
 
-- [Complete Guide: How to Integrate Beehiiv with Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
+- [Complete Guide: How to Integrate Beehiiv to Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
 - [NixOS - Virtual Machine using QEMU]({{< relref "posts/nixos-vm1/" >}})
 - [Fix Proxmox Web Interface Login Errors; a Step-by-Step Guide]({{< relref "posts/troubleshooting-proxmox-login-interface/" >}})
 

--- a/content/en/posts/troubleshooting-proxmox-login-interface.md
+++ b/content/en/posts/troubleshooting-proxmox-login-interface.md
@@ -151,7 +151,7 @@ By implementing these preventative measures, you can significantly reduce the ri
 Read also:
 
 - [Using Oracle Cloud Free tier]({{< relref "posts/oracle_cloud_vps/" >}})
-- [Complete Guide: How to Integrate Beehiiv with Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
+- [Complete Guide: How to Integrate Beehiiv to Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
 - [Script for Updating Open WebUI in a Proxmox LXC]({{< relref "posts/script-update-open_webui-lxc/" >}})
 
 ---

--- a/content/pt/posts/_index.md
+++ b/content/pt/posts/_index.md
@@ -6,5 +6,5 @@ translation_source_hash: a4cc594fabc2f90d8501a74da0830cd65c555507bca9fd46d2b79b4
 Leia também:
 
 - [Introdução ao meu novo espaço na internet]({{< relref "posts/introduction/" >}})
-- [Roteiro Ambicioso de Automação do INPI]({{< relref "posts/inpi-automation-roadmap-2025-2029/" >}})
+- [Roteiro ambicioso de automação do INPI]({{< relref "posts/inpi-automation-roadmap-2025-2029/" >}})
 - [O Problema de Copiar e Colar da IA: Matando o Bloqueio de Software & Por Que a Portabilidade de Dados é Fundamental]({{< relref "posts/ai-copy-paste-problem/" >}})

--- a/content/pt/posts/hugo-content-file-structure.md
+++ b/content/pt/posts/hugo-content-file-structure.md
@@ -54,8 +54,8 @@ Minhas referências para isso estão um pouco espalhadas, mas aqui estão elas:
 
 Leia também:
 
-- [Guia Completo: Como Integrar Beehiiv com Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
-- [Usando o nível gratuito do Oracle Cloud]({{< relref "posts/oracle_cloud_vps/" >}})
+- [Guia Completo: Como Integrar o Beehiiv ao Hugo via Cloudflare Workers]({{< relref "posts/newsletter-beehiiv-cloudflare-github/" >}})
+- [Usando a Camada Gratuita do Oracle Cloud]({{< relref "posts/oracle_cloud_vps/" >}})
 - [Introdução ao meu novo espaço na internet]({{< relref "posts/introduction/" >}})
 
 ---

--- a/content/pt/posts/introduction.md
+++ b/content/pt/posts/introduction.md
@@ -70,5 +70,5 @@ Meus planos para este blog são mostrar meu trabalho, seja em propriedade intele
 Leia também:
 
 - [10 anos usando o MacBook Pro 9,2]({{< relref "posts/10-years-of-macbook-pro/" >}})
-- [Atualização de vida - Novembro de 2023]({{< relref "posts/update_on_life_november-2023/" >}})
+- [Atualização de Vida — Novembro de 2023]({{< relref "posts/update_on_life_november-2023/" >}})
 - [Pensamentos sobre o hu.ma.ne AI Pin]({{< relref "posts/ai-pin/" >}})

--- a/scripts/posts-index.json
+++ b/scripts/posts-index.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-05-05T01:37:53.145Z",
+  "last_updated": "2026-05-05T02:07:19.158Z",
   "posts": {
     "10-obsidian-copilot": {
       "slug": "10-obsidian-copilot",
@@ -358,7 +358,7 @@
     },
     "ia-desenvolvimento-software-complexidade-codigo": {
       "slug": "ia-desenvolvimento-software-complexidade-codigo",
-      "title_en": "From Developers to Scientists: How AI Is Transforming the Complexity of Code",
+      "title_en": "From Developers to Scientists: How AI Is Transforming Code Complexity",
       "title_pt": "De Desenvolvedores a Cientistas: Como a IA Está Transformando a Complexidade do Código",
       "tags": [
         "inteligência artificial",
@@ -372,8 +372,8 @@
       "categories": [
         "article"
       ],
-      "description_en": "The increasing use of Artificial Intelligence in software development is creating systems so complex that, in the future, programmers will act as scientists.",
-      "content_hash_en": "04fc5ea3ec54abf70d300e0d4e22dc079c89b7a42d91040f91e542e1b520caa9",
+      "description_en": "The growing use of Artificial Intelligence in software development is creating systems so complex that, in the future, programmers will act as scientists.",
+      "content_hash_en": "b79b7505caf74180481e5b95fdbe17d9edae50e680c9e6e80287d7b18c496f66",
       "backlinks": [
         "ai-copy-paste-problem",
         "experience-with-cursor-and-windsurf",
@@ -385,7 +385,7 @@
     "inpi-automation-roadmap-2025-2029": {
       "slug": "inpi-automation-roadmap-2025-2029",
       "title_en": "INPI's Ambitious Automation Roadmap",
-      "title_pt": "Roteiro Ambicioso de Automação do INPI",
+      "title_pt": "Roteiro ambicioso de automação do INPI",
       "tags": [
         "intelectual property",
         "technology",
@@ -437,7 +437,7 @@
     },
     "newsletter-beehiiv-cloudflare-github": {
       "slug": "newsletter-beehiiv-cloudflare-github",
-      "title_en": "Complete Guide: How to Integrate Beehiiv with Hugo via Cloudflare Workers",
+      "title_en": "Complete Guide: How to Integrate Beehiiv to Hugo via Cloudflare Workers",
       "title_pt": "Guia Completo: Como Integrar o Beehiiv ao Hugo via Cloudflare Workers",
       "tags": [
         "beehiiv",
@@ -451,7 +451,7 @@
         "tutorial"
       ],
       "description_en": "Learn to integrate a custom Beehiiv form into a Hugo website on GitHub Pages, using Cloudflare Workers and monitoring via PostHog.",
-      "content_hash_en": "10184ee803aa6ff31c6443da9cc7b4f89952eb686214bf4f2254f82f01ab1427",
+      "content_hash_en": "68017ce55e19422a810f36aa9353363d6822b915bc1bc59cbe4b9e3609059f83",
       "backlinks": [
         "oracle_cloud_vps",
         "troubleshooting-proxmox-login-interface",

--- a/scripts/suggest-backlinks.js
+++ b/scripts/suggest-backlinks.js
@@ -169,7 +169,7 @@ function saveIndex(index) {
 
 // PHASE 1+2: Scan EN posts and build/update index
 function scanPosts(index) {
-  const files = fs.readdirSync(EN_DIR).filter((f) => f.endsWith('.md'));
+  const files = fs.readdirSync(EN_DIR).filter((f) => f.endsWith('.md') && f !== '_index.md');
 
   for (const file of files) {
     const slug = file.replace(/\.md$/, '');

--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -163,56 +163,69 @@ async function syncDirectories() {
   let translatedCount = 0;
   const MAX_TRANSLATIONS = 5;
 
+  // Separate missing-file entries (priority) from update entries
+  const missing = [];
+  const updates = [];
+
   for (const [relPath, files] of fileMap.entries()) {
     if (!relPath.endsWith('.md')) continue;
-
-    if (translatedCount >= MAX_TRANSLATIONS) {
-      console.log(`Reached maximum translations limit (${MAX_TRANSLATIONS}) for this run.`);
-      break;
+    if (!files.en || !files.pt) {
+      missing.push([relPath, files]);
+    } else {
+      updates.push([relPath, files]);
     }
+  }
 
-    const enPath = files.en;
-    const ptPath = files.pt;
-
-    let didTranslate = false;
-
-    if (enPath && !ptPath) {
-      // Missing in PT
-      await translateFile(enPath, path.join(PT_DIR, relPath), 'Portuguese');
-      didTranslate = true;
-    } else if (ptPath && !enPath) {
-      // Missing in EN
-      await translateFile(ptPath, path.join(EN_DIR, relPath), 'English');
-      didTranslate = true;
-    } else if (enPath && ptPath) {
-      // Both exist, check for updates
-      const enRaw = fs.readFileSync(enPath, 'utf8');
-      const ptRaw = fs.readFileSync(ptPath, 'utf8');
-      
-      const enParsed = matter(enRaw);
-      const ptParsed = matter(ptRaw);
-
-      const enHash = getHash(enRaw);
-      const ptHash = getHash(ptRaw);
-
-      // If PT was translated from EN, and EN has changed
-      if (ptParsed.data.translation_source_hash && ptParsed.data.translation_source_hash !== enHash) {
-         console.log(`Update detected in EN: ${relPath}`);
-         await translateFile(enPath, ptPath, 'Portuguese');
-         didTranslate = true;
-      } 
-      // If EN was translated from PT, and PT has changed
-      else if (enParsed.data.translation_source_hash && enParsed.data.translation_source_hash !== ptHash) {
-         console.log(`Update detected in PT: ${relPath}`);
-         await translateFile(ptPath, enPath, 'English');
-         didTranslate = true;
+  for (const group of [missing, updates]) {
+    for (const [relPath, files] of group) {
+      if (translatedCount >= MAX_TRANSLATIONS) {
+        console.log(`Reached maximum translations limit (${MAX_TRANSLATIONS}) for this run.`);
+        break;
       }
-      // If neither has a hash (old files), we might just skip or we could compare mtimes as a fallback.
-      // For safety, we skip them until they are manually updated or run.
-    }
 
-    if (didTranslate) {
-      translatedCount++;
+      const enPath = files.en;
+      const ptPath = files.pt;
+
+      let didTranslate = false;
+
+      if (enPath && !ptPath) {
+        // Missing in PT
+        await translateFile(enPath, path.join(PT_DIR, relPath), 'Portuguese');
+        didTranslate = true;
+      } else if (ptPath && !enPath) {
+        // Missing in EN
+        await translateFile(ptPath, path.join(EN_DIR, relPath), 'English');
+        didTranslate = true;
+      } else if (enPath && ptPath) {
+        // Both exist, check for updates
+        const enRaw = fs.readFileSync(enPath, 'utf8');
+        const ptRaw = fs.readFileSync(ptPath, 'utf8');
+
+        const enParsed = matter(enRaw);
+        const ptParsed = matter(ptRaw);
+
+        const enHash = getHash(enRaw);
+        const ptHash = getHash(ptRaw);
+
+        // If PT was translated from EN, and EN has changed
+        if (ptParsed.data.translation_source_hash && ptParsed.data.translation_source_hash !== enHash) {
+           console.log(`Update detected in EN: ${relPath}`);
+           await translateFile(enPath, ptPath, 'Portuguese');
+           didTranslate = true;
+        }
+        // If EN was translated from PT, and PT has changed
+        else if (enParsed.data.translation_source_hash && enParsed.data.translation_source_hash !== ptHash) {
+           console.log(`Update detected in PT: ${relPath}`);
+           await translateFile(ptPath, enPath, 'English');
+           didTranslate = true;
+        }
+        // If neither has a hash (old files), we might just skip or we could compare mtimes as a fallback.
+        // For safety, we skip them until they are manually updated or run.
+      }
+
+      if (didTranslate) {
+        translatedCount++;
+      }
     }
   }
 }


### PR DESCRIPTION
## What changed

### `scripts/translate.js`
`syncDirectories()` previously iterated all files in a single loop with a shared `MAX_TRANSLATIONS = 5` cap. When several existing posts had stale hashes and needed re-translation, those 5 slots were consumed before any newly added single-language post (e.g. a PT-only article) could have its counterpart created.

The loop is now split into two passes:
1. **Pass 1 – Missing files (priority):** entries where only one language file exists. These run first and exhaust capacity before updates are attempted.
2. **Pass 2 – Updates:** entries where both files exist but the `translation_source_hash` is stale.

### `scripts/suggest-backlinks.js`
`scanPosts()` was reading every `.md` file from `EN_DIR`, including `_index.md` (Hugo section index). Added `&& f !== '_index.md'` to the filter so it is never indexed as a real post.

## Why

A new PT-only post (`linux-windows-macos-qual-usar-2026.md`) was being permanently ignored by `suggest-backlinks` because:
1. `translate.js` never created the EN version — update slots filled up first.
2. `suggest-backlinks` only scans `EN_DIR`, so without an EN file the post was invisible to it.

## Reviewer notes

- No new dependencies or config changes.
- The `MAX_TRANSLATIONS` cap still applies across both passes combined — behaviour is unchanged when there are no missing files.
- After the next CI push, `translate.js` will create the EN linux post; the following `suggest-backlinks` run will then index it and apply backlinks to both language versions.