### PR TITLE
fix(seo): detect PT-only posts in suggest-backlinks script

### DIFF
--- a/scripts/posts-index.json
+++ b/scripts/posts-index.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-05-06T01:12:24.744Z",
+  "last_updated": "2026-05-06T01:22:39.777Z",
   "posts": {
     "10-obsidian-copilot": {
       "slug": "10-obsidian-copilot",
@@ -766,7 +766,7 @@
         "article"
       ],
       "description_en": "An analysis of the article 'When Dawkins met Claude'. Can language models like Claude be conscious, or are we just falling for the Turing Test?",
-      "content_hash_en": "d558d6091b1e2232654b34dc1cc202d607d06c8104a986bd91f7fa332a847cf1",
+      "content_hash_en": "adfa2e02ec162a04d2acc9355f33301dfd20b2a718e19342902a7290baf05b2f",
       "backlinks": [
         "anthropic-thinking-process-paper",
         "vibe-coding-pitfalls",

--- a/scripts/suggest-backlinks.js
+++ b/scripts/suggest-backlinks.js
@@ -96,20 +96,20 @@ async function suggestBacklinks(targetSlug, targetPost, allPosts, retries = 5) {
     .filter((p) => p.slug !== targetSlug)
     .map((p) => ({
       slug: p.slug,
-      title: p.title_en,
+      title: p.title_en || p.title_pt,
       tags: p.tags,
       categories: p.categories,
-      description: p.description_en,
+      description: p.description_en || p.description_pt || '',
     }));
 
   const prompt = `You manage a technical blog. Your task is to find the 3 most thematically related posts for a given post.
 
 TARGET POST:
 slug: ${targetSlug}
-title: ${targetPost.title_en}
+title: ${targetPost.title_en || targetPost.title_pt}
 tags: ${JSON.stringify(targetPost.tags)}
 categories: ${JSON.stringify(targetPost.categories)}
-description: ${targetPost.description_en}
+description: ${targetPost.description_en || targetPost.description_pt || ''}
 
 CANDIDATE POSTS:
 ${JSON.stringify(candidates, null, 2)}
@@ -220,6 +220,55 @@ function scanPosts(index) {
       categories: enParsed.data.categories || [],
       description_en: enParsed.data.description || '',
       content_hash_en: enHash,
+      backlinks,
+      backlink_source: backlinkSource,
+      last_processed: prev.last_processed || null,
+    };
+  }
+
+  // Second pass: detect PT-only posts (no EN equivalent yet)
+  const ptFiles = fs.readdirSync(PT_DIR).filter((f) => f.endsWith('.md') && f !== '_index.md');
+  for (const file of ptFiles) {
+    const slug = file.replace(/\.md$/, '');
+    if (index.posts[slug]) continue; // already handled by EN scan
+
+    const ptPath = path.join(PT_DIR, file);
+    const ptRaw = fs.readFileSync(ptPath, 'utf8');
+    const ptParsed = matter(ptRaw);
+    const ptHash = getHash(ptRaw);
+
+    const prev = index.posts[slug] || {};
+    const hashChanged = prev.content_hash_pt !== ptHash;
+
+    const fmEnd = frontmatterEnd(ptRaw);
+    const body = ptRaw.slice(fmEnd);
+    const fromFile = extractBacklinkSlugs(body);
+
+    let backlinks = prev.backlinks || [];
+    let backlinkSource = prev.backlink_source || 'none';
+
+    if (fromFile.length >= MIN_BACKLINKS) {
+      backlinks = fromFile.slice(0, MIN_BACKLINKS);
+      backlinkSource = 'file';
+    } else if (hashChanged || backlinks.length < MIN_BACKLINKS) {
+      if (prev.backlinks && prev.backlinks.length >= MIN_BACKLINKS && !hashChanged) {
+        backlinks = prev.backlinks;
+        backlinkSource = prev.backlink_source || 'ai';
+      } else {
+        backlinks = fromFile;
+        backlinkSource = 'pending';
+      }
+    }
+
+    index.posts[slug] = {
+      slug,
+      title_en: prev.title_en || ptParsed.data.title || slug,
+      title_pt: ptParsed.data.title || slug,
+      tags: ptParsed.data.tags || [],
+      categories: ptParsed.data.categories || [],
+      description_en: prev.description_en || ptParsed.data.description || '',
+      content_hash_en: null,
+      content_hash_pt: ptHash,
       backlinks,
       backlink_source: backlinkSource,
       last_processed: prev.last_processed || null,


### PR DESCRIPTION
## Summary

- `scanPosts()` now does a second pass over `content/pt/posts/` to detect posts that exist in PT but have no EN equivalent yet
- PT-only posts are indexed with `content_hash_pt` for change tracking, and marked `pending` so the AI generates backlinks for them
- Backlinks are written to the PT file immediately; when `translate.js` later creates the EN version, it carries the "Leia também:" section (translated to "Read also:") automatically
- `suggestBacklinks()` now uses `title_en || title_pt` and `description_en || description_pt` as fallbacks so the Gemini prompt works correctly for PT-only posts

## Root cause

When a new PT post is pushed, `suggest-backlinks` only scanned `content/en/posts/` and missed it. Translate then created the EN version, but that commit uses `GITHUB_TOKEN` — GitHub blocks `GITHUB_TOKEN`-authored pushes from re-triggering other workflows. So the backlinks workflow never ran again for the new EN file.

## Test plan

- [ ] Push a new PT post to `content/pt/posts/`
- [ ] Verify the backlinks workflow log shows the new slug in `Posts needing backlink suggestions`
- [ ] Verify the PT file gets a "Leia também:" section with 3 links
- [ ] Verify `scripts/posts-index.json` contains the new slug with `backlink_source: "ai"`
- [ ] After translate runs, verify the EN file has a "Read also:" section with the same 3 slugs

🤖 Generated with [Claude Code](https://claude.com/claude-code)