### PR TITLE
feat(blog): fix tag filtering + add search bar and collapsible tag panel

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -855,27 +855,63 @@ a { color: inherit; text-decoration: none; }
    ========================================================= */
 .blog-wrap { padding: var(--space-7) 0; }
 .blog-toolbar {
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding: var(--space-4) 0;
   border-bottom: 1px solid var(--border);
   margin-bottom: var(--space-5);
   font-family: var(--font-mono);
   font-size: 12px;
+}
+.blog-search-row {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  gap: var(--space-4);
   flex-wrap: wrap;
-  gap: var(--space-3);
+  margin-bottom: var(--space-3);
 }
 .blog-toolbar .count {
   color: var(--fg-faint);
   letter-spacing: 0.08em;
 }
 .blog-toolbar .count strong { color: var(--fg); font-weight: 500; }
-.blog-tags {
-  display: flex;
-  gap: var(--space-2);
-  flex-wrap: wrap;
+.blog-search-input {
+  flex: 1;
+  max-width: 360px;
+  padding: 6px 14px;
+  border: 1px solid var(--border);
+  border-radius: 100px;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg);
+  background: var(--bg);
+  outline: none;
+  transition: border-color 0.15s;
 }
+.blog-search-input:focus { border-color: var(--fg); }
+.blog-search-input::placeholder { color: var(--fg-faint); }
+.blog-filter-row { padding-bottom: var(--space-3); }
+.blog-tags-toggle {
+  background: none;
+  border: none;
+  font-family: var(--font-mono);
+  font-size: 12px;
+  color: var(--fg-muted);
+  cursor: pointer;
+  letter-spacing: 0.05em;
+  padding: 0;
+}
+.blog-tags-toggle:hover { color: var(--fg); }
+.blog-tags-count { color: var(--fg-faint); margin-left: 4px; }
+.blog-tags-panel {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--space-2);
+  margin-top: var(--space-3);
+  overflow: hidden;
+  max-height: 0;
+  transition: max-height 0.35s ease;
+}
+.blog-tags-panel[aria-hidden="false"] { max-height: 800px; }
 .blog-tag-btn {
   padding: 5px 12px;
   border: 1px solid var(--border);

--- a/assets/js/tag-filter.js
+++ b/assets/js/tag-filter.js
@@ -1,26 +1,63 @@
 (function () {
-  var buttons = document.querySelectorAll('.blog-tag-btn');
-  var entries = document.querySelectorAll('.blog-entry');
-  var countEl = document.querySelector('.blog-count');
-  if (!buttons.length) return;
+  var entries    = document.querySelectorAll('.blog-entry');
+  var countEl    = document.querySelector('.blog-count');
+  var searchEl   = document.getElementById('blog-search');
+  var toggle     = document.getElementById('blog-tags-toggle');
+  var panel      = document.getElementById('blog-tags-panel');
+  var activeTag  = 'all';
+  var activeQuery = '';
 
-  function filter(tag) {
+  // ── Collapse toggle ──────────────────────────────────────
+  if (toggle && panel) {
+    toggle.addEventListener('click', function () {
+      var open = toggle.getAttribute('aria-expanded') === 'true';
+      var next = !open;
+      toggle.setAttribute('aria-expanded', String(next));
+      panel.setAttribute('aria-hidden', String(!next));
+      var count = panel.querySelectorAll('.blog-tag-btn').length;
+      toggle.innerHTML = (next ? '▼' : '▶') +
+        ' Filter by tag <span class="blog-tags-count">(' + count + ' available)</span>';
+    });
+  }
+
+  // ── Core filter ──────────────────────────────────────────
+  function applyFilters() {
+    var q = activeQuery.toLowerCase().trim();
     var visible = 0;
     entries.forEach(function (entry) {
-      var entryTag = entry.getAttribute('data-tag') || '';
-      var show = tag === 'all' || entryTag.toLowerCase() === tag.toLowerCase();
+      var tags    = (entry.getAttribute('data-tags') || '').toLowerCase();
+      var title   = (entry.getAttribute('data-title') || '').toLowerCase();
+      var excerpt = (entry.getAttribute('data-excerpt') || '').toLowerCase();
+
+      var tagMatch  = activeTag === 'all' || tags.split(' ').indexOf(activeTag) !== -1;
+      var textMatch = !q || title.indexOf(q) !== -1 || excerpt.indexOf(q) !== -1 || tags.indexOf(q) !== -1;
+
+      var show = tagMatch && textMatch;
       entry.setAttribute('data-hidden', show ? 'false' : 'true');
       if (show) visible++;
     });
     if (countEl) countEl.textContent = visible;
-    buttons.forEach(function (btn) {
-      btn.classList.toggle('active', btn.getAttribute('data-filter') === tag);
-    });
   }
 
+  // ── Tag buttons ──────────────────────────────────────────
+  var buttons = document.querySelectorAll('.blog-tag-btn');
   buttons.forEach(function (btn) {
     btn.addEventListener('click', function () {
-      filter(btn.getAttribute('data-filter') || 'all');
+      activeTag = btn.getAttribute('data-filter') || 'all';
+      buttons.forEach(function (b) {
+        b.classList.toggle('active', b.getAttribute('data-filter') === activeTag);
+      });
+      var label = document.getElementById('active-tag-label');
+      if (label) label.textContent = activeTag !== 'all' ? '#' + activeTag : '';
+      applyFilters();
     });
   });
+
+  // ── Search input ─────────────────────────────────────────
+  if (searchEl) {
+    searchEl.addEventListener('input', function () {
+      activeQuery = searchEl.value;
+      applyFilters();
+    });
+  }
 })();

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -19,22 +19,34 @@
   <div class="container">
 
     {{/* Toolbar */}}
+    {{ $tags := slice }}
+    {{ range $allPosts }}
+      {{ range .Params.tags }}
+        {{ $tags = $tags | append . }}
+      {{ end }}
+    {{ end }}
     <div class="blog-toolbar">
-      <div class="count">
-        <span class="blog-count">{{ len $allPosts }}</span> essays
-        <strong id="active-tag-label"></strong>
+      <div class="blog-search-row">
+        <div class="count">
+          <span class="blog-count">{{ len $allPosts }}</span> essays
+          <strong id="active-tag-label"></strong>
+        </div>
+        <input
+          id="blog-search"
+          class="blog-search-input"
+          type="search"
+          placeholder="Search posts..."
+          aria-label="Search posts"
+        />
       </div>
-      <div class="blog-tags">
-        <button class="blog-tag-btn active" data-filter="all">all</button>
-        {{ $tags := slice }}
-        {{ range $allPosts }}
-          {{ range .Params.tags }}
-            {{ $tags = $tags | append . }}
+      <div class="blog-filter-row">
+        <button id="blog-tags-toggle" class="blog-tags-toggle" aria-expanded="false">▶ Filter by tag <span class="blog-tags-count">({{ len ($tags | uniq) }} available)</span></button>
+        <div id="blog-tags-panel" class="blog-tags-panel" aria-hidden="true">
+          <button class="blog-tag-btn active" data-filter="all">all</button>
+          {{ range ($tags | uniq) }}
+          <button class="blog-tag-btn" data-filter="{{ . | lower }}">{{ . | lower }}</button>
           {{ end }}
-        {{ end }}
-        {{ range ($tags | uniq) }}
-        <button class="blog-tag-btn" data-filter="{{ . | lower }}">{{ . | lower }}</button>
-        {{ end }}
+        </div>
       </div>
     </div>
 
@@ -42,7 +54,9 @@
     <div class="blog-list">
       {{ range $allPosts }}
       <article class="blog-entry"
-        data-tag="{{ with .Params.tags }}{{ index . 0 | lower }}{{ end }}"
+        data-tags="{{ with .Params.tags }}{{ range . }}{{ . | lower }} {{ end }}{{ end }}"
+        data-title="{{ .Title | lower }}"
+        data-excerpt="{{ .Summary | truncate 160 | plainify | lower }}"
         onclick="window.location='{{ .RelPermalink }}'">
         <div class="blog-entry-date">
           {{ .Date.Format "Jan 02" }}


### PR DESCRIPTION
## Summary

- **Fix multi-tag filtering bug** — posts were only matched against their first tag (`data-tag`). Now all tags are stored in `data-tags` (space-separated) and the JS checks every tag, so clicking e.g. *obsidian* correctly surfaces posts where obsidian is the 2nd, 3rd, or Nth tag.
- **Add real-time search bar** — filters posts by title, excerpt, and tags as the user types.
- **Collapsible tag panel** — replaces the flat, ever-growing pill grid with a `▶ Filter by tag (N available)` toggle that expands/collapses with a smooth CSS transition (closed by default).

## Files changed

| File | Change |
|------|--------|
| `layouts/_default/list.html` | New toolbar HTML: search input + collapsible tag panel; `data-tags`/`data-title`/`data-excerpt` on each article |
| `assets/js/tag-filter.js` | Rewritten: multi-tag matching, text search, collapse toggle |
| `assets/css/main.css` | New styles for search input, toggle button, and animated panel |

## Test plan

- [ ] Open `/posts/` — toolbar shows count, search input, and collapsed tag toggle
- [ ] Click **▶ Filter by tag** → panel expands showing all tag pills; click again → collapses
- [ ] Click **obsidian** → post *"Obsidian Copilot…"* appears (was broken before)
- [ ] Type "obsidian" in search → same post appears
- [ ] Combine tag filter + search text → intersection applied correctly
- [ ] Verify on `/pt/posts/` (Portuguese version) as well

🤖 Generated with [Claude Code](https://claude.com/claude-code)