### PR TITLE
feat(blog): add newsletter CTA and Buy Me a Coffee to /posts page

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -999,6 +999,16 @@ a { color: inherit; text-decoration: none; }
 }
 
 /* =========================================================
+   BLOG LIST CTAs
+   ========================================================= */
+.blog-list-ctas {
+  margin-top: var(--space-8);
+  border-top: 1px solid var(--border);
+  padding-top: var(--space-7);
+}
+.blog-list-ctas .bmc-wrap { margin-top: 0; }
+
+/* =========================================================
    SINGLE POST
    ========================================================= */
 .post-wrap {

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -75,6 +75,11 @@
       {{ end }}
     </div>
 
+    {{/* ── Bottom CTAs ── */}}
+    <div class="blog-list-ctas">
+      {{ partial "newsletter-end-cta.html" . }}
+      {{ partial "buy-me-coffee.html" . }}
+    </div>
 
 </div>
 </section>


### PR DESCRIPTION
## Summary

- Adds the newsletter signup block (author bio, email form, credentials) at the bottom of `/posts`
- Adds the Buy Me a Coffee button below it, separated by a divider
- Both reuse existing partials (`newsletter-end-cta.html`, `buy-me-coffee.html`), so any updates to those partials are reflected automatically
- Added `.blog-list-ctas` wrapper with top border and spacing to visually separate CTAs from the post list

## Test plan

- [ ] Open `/posts` and scroll to the bottom — newsletter CTA and BMAC button appear after the last post
- [ ] Verify on `/pt/posts` — text renders in Portuguese (Inscrever-se, Pague-me um café)
- [ ] Submit an email in the newsletter form — success state shows correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)