### PR TITLE
feat: add ads.txt to static/ for Google AdSense

### DIFF
--- a/static/ads.txt
+++ b/static/ads.txt
@@ -1,0 +1,1 @@
+google.com, pub-9060440160120562, DIRECT, f08c47fec0942fa0


### PR DESCRIPTION
## Summary

- Created `static/ads.txt` with the Google AdSense publisher line
- The file existed at the repo root but Hugo only publishes files from `static/`, so it was never deployed

## Why

Google AdSense requires `ads.txt` to be accessible at `https://lucasaguiar.xyz/ads.txt`. The status showed "not found" because Hugo ignores files in the repo root — only `static/` content is copied to the generated site.

## Reviewer notes

No code changes, just a one-line text file in the right directory. After merging to `master`, the GitHub Actions Hugo build will include it and GitHub Pages will serve it at the expected URL. AdSense may take up to 24h to detect the update.

🤖 Generated with [Claude Code](https://claude.com/claude-code)