### PR TITLE
feat(blog): improve table rendering with LaTeX-style design and wider layout

### DIFF
--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -1175,6 +1175,47 @@ a { color: inherit; text-decoration: none; }
   border-radius: 2px;
   margin: var(--space-5) auto;
 }
+
+/* ── Tables ── */
+.table-scroll {
+  overflow-x: auto;
+  -webkit-overflow-scrolling: touch;
+  margin: var(--space-7) -80px;
+}
+@media (max-width: 900px) {
+  .table-scroll {
+    margin-left: calc(-1 * var(--space-5));
+    margin-right: calc(-1 * var(--space-5));
+  }
+}
+.post-body table {
+  width: 100%;
+  border-collapse: collapse;
+  font-family: var(--font-sans);
+  font-size: 0.875rem;
+  line-height: 1.5;
+  color: var(--fg);
+}
+.post-body thead th {
+  border-top: 2px solid var(--fg);
+  border-bottom: 1px solid var(--fg);
+  padding: var(--space-2) var(--space-4);
+  font-weight: 600;
+  text-align: center;
+  font-size: 0.8125rem;
+  letter-spacing: 0.02em;
+  white-space: nowrap;
+}
+.post-body thead th:first-child { text-align: left; }
+.post-body tbody td {
+  padding: var(--space-2) var(--space-4);
+  border-bottom: 1px solid var(--border);
+  vertical-align: top;
+}
+.post-body tbody tr:last-child td {
+  border-bottom: 2px solid var(--fg);
+}
+
 .post-tags {
   max-width: 680px;
   margin: var(--space-7) auto var(--space-5);

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -98,4 +98,16 @@
   update();
 })();
 </script>
+
+{{/* Wrap tables for wider layout + horizontal scroll */}}
+<script>
+(function () {
+  document.querySelectorAll('.post-body table').forEach(function (t) {
+    var w = document.createElement('div');
+    w.className = 'table-scroll';
+    t.parentNode.insertBefore(w, t);
+    w.appendChild(t);
+  });
+})();
+</script>
 {{ end }}


### PR DESCRIPTION
## Summary

- Add CSS table styles to `assets/css/main.css`: minimal LaTeX-inspired design (horizontal rules only, no vertical lines), `Inter` font at 14px, double border on `thead` and last row
- Add `.table-scroll` wrapper class that bleeds ±80px beyond the 680px post body on desktop, with `overflow-x: auto` for wide tables
- Add inline JS to `layouts/_default/single.html` that automatically wraps every `.post-body table` in a `.table-scroll` div (needed because Hugo/Goldmark has no render hook for tables)

## Test plan

- [ ] Run `hugo server` and open a post with a markdown table
- [ ] Confirm table is ~160px wider than the surrounding text
- [ ] Confirm dark mode renders correctly (styles use `--fg` and `--border` CSS variables)
- [ ] Resize to < 900px and confirm horizontal scroll works without viewport overflow

🤖 Generated with [Claude Code](https://claude.com/claude-code)