### PR TITLE
fix(translate): prevent YAML block scalars in generated frontmatter

### DIFF
--- a/content/en/posts/adi-5529-patentes-farmaceuticas.md
+++ b/content/en/posts/adi-5529-patentes-farmaceuticas.md
@@ -53,9 +53,9 @@ The underlying issue remains the same that motivated the ADI: as long as the INP
 
 Read also:
 
-- [Patent Term Adjustment: Big Pharma Lost in Court, but the Debate Reached Congress]({{< relref "posts/propostas_pta_patentes_2026/" >}})
+- [propostas_pta_patente_2026]({{< relref "posts/propostas_pta_patente_2026/" >}})
 - [The INPI backlog is over — but not for drug patents]({{< relref "posts/backlog-inpi-patentes-farmaceuticas/" >}})
-- [Ambitious INPI automation roadmap]({{< relref "posts/inpi-automation-roadmap-2025-2029/" >}})
+- [Patent Term Adjustment: Big Pharma lost in court, but the debate reached Congress]({{< relref "posts/propostas_pta_patentes_2026/" >}})
 
 ---
 

--- a/content/en/posts/adi-5529-patentes-farmaceuticas.md
+++ b/content/en/posts/adi-5529-patentes-farmaceuticas.md
@@ -1,7 +1,7 @@
 ---
 date: 2026-05-10T13:30:00.000Z
 draft: false
-title: '## ADI 5.529: the STF''s decision that shortened drug patents in Brazil'
+title: 'ADI 5.529: the STF''s decision that shortened drug patents in Brazil'
 description: >-
   In 2021, the STF (Supreme Federal Court) struck down the provision that
   guaranteed a minimum 10-year validity period after patent grants. Understand

--- a/content/en/posts/adi-5529-patentes-farmaceuticas.md
+++ b/content/en/posts/adi-5529-patentes-farmaceuticas.md
@@ -2,12 +2,10 @@
 date: 2026-05-10T13:30:00.000Z
 draft: false
 title: 'ADI 5.529: the STF''s decision that shortened drug patents in Brazil'
-description: >-
-  In 2021, the STF (Supreme Federal Court) struck down the provision that
+description: "In 2021, the STF (Supreme Federal Court) struck down the provision that
   guaranteed a minimum 10-year validity period after patent grants. Understand
-  what changed, which patents were affected, and the impact on drug prices.
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-adi-5529-2.png
+  what changed, which patents were affected, and the impact on drug prices."
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-adi-5529-2.png
 categories:
   - article
 tags:

--- a/content/en/posts/backlog-inpi-patentes-farmaceuticas.md
+++ b/content/en/posts/backlog-inpi-patentes-farmaceuticas.md
@@ -1,13 +1,11 @@
 ---
 date: 2026-04-28T13:00:00.000Z
 draft: false
-title: The INPI backlog is over — but not for drug patents
-description: >-
-  The Backlog Combat Plan reduced the overall stock by 80%, but pharmaceutical
+title: "The INPI backlog is over — but not for drug patents"
+description: "The Backlog Combat Plan reduced the overall stock by 80%, but pharmaceutical
   orders were left out. Understand what changed with Ordinance 110/2025 and what
-  is still pending.
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-inpi-backlog-2026.png
+  is still pending."
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-inpi-backlog-2026.png
 categories:
   - article
 tags:

--- a/content/en/posts/dawkins-claude-consciencia-ia.md
+++ b/content/en/posts/dawkins-claude-consciencia-ia.md
@@ -2,12 +2,10 @@
 date: 2026-05-06T00:26:21.000Z
 draft: false
 title: 'Dawkins, Claude and the Myth of Consciousness in Artificial Intelligence'
-description: >-
-  An analysis of the article 'When Dawkins met Claude'. Can language models like
-  Claude be conscious, or are we just falling for the Turing Test?
+description: "An analysis of the article 'When Dawkins met Claude'. Can language models like
+  Claude be conscious, or are we just falling for the Turing Test?"
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-claude-dawkins.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-claude-dawkins.png
 categories:
   - article
 tags:

--- a/content/en/posts/ia-desenvolvimento-software-complexidade-codigo.md
+++ b/content/en/posts/ia-desenvolvimento-software-complexidade-codigo.md
@@ -2,9 +2,8 @@
 date: 2026-05-01T13:05:07.000Z
 draft: true
 title: 'From Developers to Scientists: How AI Is Transforming Code Complexity'
-description: >-
-  The growing use of Artificial Intelligence in software development is creating
-  systems so complex that, in the future, programmers will act as scientists.
+description: "The growing use of Artificial Intelligence in software development is creating
+  systems so complex that, in the future, programmers will act as scientists."
 url: ''
 featured_image: null
 categories:

--- a/content/en/posts/linux-windows-macos-qual-usar-2026.md
+++ b/content/en/posts/linux-windows-macos-qual-usar-2026.md
@@ -2,13 +2,11 @@
 date: 2026-05-05T00:06:23.000Z
 draft: false
 title: 'Linux, Windows or macOS: Which Operating System to Use in 2026?'
-description: >-
-  Honest perspective from someone who used all three systems for years — why I
+description: "Honest perspective from someone who used all three systems for years — why I
   chose macOS, when Linux is really worth it, and what still bothers me about
-  Windows.
+  Windows."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-macos-linux-windows-2026.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-macos-linux-windows-2026.png
 categories:
   - article
 tags:

--- a/content/en/posts/newsletter-beehiiv-cloudflare-github.md
+++ b/content/en/posts/newsletter-beehiiv-cloudflare-github.md
@@ -2,12 +2,10 @@
 date: 2026-05-03T17:48:11.000Z
 draft: false
 title: 'Complete Guide: How to Integrate Beehiiv with Hugo via Cloudflare Workers'
-description: >-
-  Learn how to integrate a custom Beehiiv form into a Hugo website on GitHub
-  Pages, using Cloudflare Workers and monitoring via PostHog.
+description: "Learn how to integrate a custom Beehiiv form into a Hugo website on GitHub
+  Pages, using Cloudflare Workers and monitoring via PostHog."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-cloudflare-beehiiv.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-cloudflare-beehiiv.png
 categories:
   - article
   - tutorial

--- a/content/en/posts/propostas_pta_patentes_2026.md
+++ b/content/en/posts/propostas_pta_patentes_2026.md
@@ -1,15 +1,12 @@
 ---
 date: 2026-04-29T15:20:00.000Z
 draft: false
-title: >-
-  Patent Term Adjustment: Big Pharma lost in court, but the debate reached
-  Congress
-description: >-
-  After the STJ denied an extension of time for semaglutide, the discussion
+title: "Patent Term Adjustment: Big Pharma lost in court, but the debate reached
+  Congress"
+description: "After the STJ denied an extension of time for semaglutide, the discussion
   about compensation for INPI's delay in pharmaceutical patents moved to the
-  Legislature. What is at stake in Bill No. 5,810/2025.
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-pta-luta-legislativa.png
+  Legislature. What is at stake in Bill No. 5,810/2025."
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-pta-luta-legislativa.png
 categories:
   - article
 tags:

--- a/content/pt/posts/10-obsidian-copilot.md
+++ b/content/pt/posts/10-obsidian-copilot.md
@@ -1,10 +1,9 @@
 ---
 date: 2025-02-04T15:00:59.000Z
 draft: false
-title: Obsidian + Copilot
-description: Usando OpenRouter para impulsionar a IA no Obsidian.
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-obsidian-copilot.png
+title: "Obsidian + Copilot"
+description: "Usando OpenRouter para impulsionar a IA no Obsidian."
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-obsidian-copilot.png
 categories:
   - tutorial
 tags:

--- a/content/pt/posts/10-years-of-macbook-pro.md
+++ b/content/pt/posts/10-years-of-macbook-pro.md
@@ -2,9 +2,8 @@
 date: 2023-11-11T00:00:00.000Z
 draft: false
 title: '10 anos usando o MacBook Pro 9,2'
-description: >-
-  10 anos com um laptop é uma jornada e tanto e inimaginável há 10 anos, e aqui
-  estamos.
+description: "10 anos com um laptop é uma jornada e tanto e inimaginável há 10 anos, e aqui
+  estamos."
 url: /macbook-pro-10years/
 featured_image: /images/macbook-2012.png
 tags:

--- a/content/pt/posts/adi-5529-patentes-farmaceuticas.md
+++ b/content/pt/posts/adi-5529-patentes-farmaceuticas.md
@@ -52,9 +52,9 @@ A questão subjacente permanece a mesma que motivou a ADI: enquanto o INPI demor
 
 Leia também:
 
-- [Patent Term Adjustment: Big Pharma perdeu na Justiça, mas o debate chegou ao Congresso]({{< relref "posts/propostas_pta_patentes_2026/" >}})
+- [propostas_pta_patente_2026]({{< relref "posts/propostas_pta_patente_2026/" >}})
 - [O backlog do INPI acabou — mas não para patentes de medicamentos]({{< relref "posts/backlog-inpi-patentes-farmaceuticas/" >}})
-- [Roteiro ambicioso de automação do INPI]({{< relref "posts/inpi-automation-roadmap-2025-2029/" >}})
+- [Patent Term Adjustment: Big Pharma perdeu na Justiça, mas o debate chegou ao Congresso]({{< relref "posts/propostas_pta_patentes_2026/" >}})
 
 ---
 

--- a/content/pt/posts/ai-beats-procrastination.md
+++ b/content/pt/posts/ai-beats-procrastination.md
@@ -2,10 +2,9 @@
 date: 2025-04-13T04:39:56.000Z
 draft: false
 title: 'Da Procrastinação ao Progresso: Como a IA me tem ajudado'
-description: null
+description: ''
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-ai-procrastination.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-ai-procrastination.png
 categories:
   - article
 tags:

--- a/content/pt/posts/ai-copy-paste-problem.md
+++ b/content/pt/posts/ai-copy-paste-problem.md
@@ -1,20 +1,16 @@
 ---
 date: 2025-03-15T03:55:28.000Z
 draft: false
-title: >-
-  O Problema de Copiar e Colar da IA: Matando o Bloqueio de Software & Por Que a
-  Portabilidade de Dados é Fundamental
-description: >-
-  A IA está a mudar o jogo para as empresas de software. O emergente "Problema
-  de Copiar e Colar da IA" sublinha a eficácia decrescente do aprisionamento de
+title: "O Problema de Copiar e Colar da IA: Matando o Bloqueio de Software & Por Que a
+  Portabilidade de Dados é Fundamental"
+description: "A IA está a mudar o jogo para as empresas de software. O emergente 'Problema
+  de Copiar e Colar da IA' sublinha a eficácia decrescente do aprisionamento de
   software. Os utilizadores agora priorizam a portabilidade de dados,
   possibilitada por ferramentas de IA acessíveis, permitindo-lhes moverem-se
   facilmente entre plataformas. Este artigo examina como as empresas podem
-  adaptar-se ao abraçar a interoperabilidade de dados para construir uma
-  lealdade genuína do cliente na era da IA.
+  adaptar-se ao abraçar a interoperabilidade de dados para construir uma lealdade genuína do cliente na era da IA."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-ai-copy-paste.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-ai-copy-paste.png
 categories:
   - article
 tags:

--- a/content/pt/posts/ai-pin.md
+++ b/content/pt/posts/ai-pin.md
@@ -1,11 +1,10 @@
 ---
 date: 2023-11-10T00:00:00.000Z
 draft: false
-description: >-
-  A startup hu.ma.ne lançou seu primeiro produto, o AI Pin. Este dispositivo é
+description: "A startup hu.ma.ne lançou seu primeiro produto, o AI Pin. Este dispositivo é
   realmente diferente e é mais um marco no início da era da IA. Um dispositivo
   feito exclusivamente para ser o assistente de IA para o povo comum. Terá
-  sucesso?
+  sucesso?"
 url: /humane-ai-pin-announcement/
 featured_image: /images/humane-ai-pin.jpeg
 tags:

--- a/content/pt/posts/ai-powered-protein-sequencing.md
+++ b/content/pt/posts/ai-powered-protein-sequencing.md
@@ -1,16 +1,13 @@
 ---
 date: 2025-04-11T17:53:35.000Z
 draft: true
-title: >-
-  O Que São Proteínas e Por Que o Sequenciamento de Proteínas por IA é um
-  Divisor de Águas?
-description: >-
-  Aprenda como a inteligência artificial está revolucionando nossa compreensão
+title: "O Que São Proteínas e Por Que o Sequenciamento de Proteínas por IA é um
+  Divisor de Águas?"
+description: "Aprenda como a inteligência artificial está revolucionando nossa compreensão
   das proteínas - os motores da vida - e transformando a medicina, a agricultura
-  e a ciência ambiental ao longo do caminho.
+  e a ciência ambiental ao longo do caminho."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-ai-protein-sequencing.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-ai-protein-sequencing.png
 categories:
   - article
 tags:

--- a/content/pt/posts/anthropic-thinking-process-paper.md
+++ b/content/pt/posts/anthropic-thinking-process-paper.md
@@ -1,16 +1,13 @@
 ---
 date: 2025-04-02T17:30:00.000Z
 draft: false
-title: >-
-  Dentro dos Cérebros de IA: Como a Anthropic Decifrou o Processo de Pensamento
-  de Claude
-description: >-
-  Uma análise de como pesquisadores estão espreitando a 'mente' de Claude e
+title: "Dentro dos Cérebros de IA: Como a Anthropic Decifrou o Processo de Pensamento
+  de Claude"
+description: "Uma análise de como pesquisadores estão espreitando a 'mente' de Claude e
   descobrindo paralelos surpreendentes com sistemas biológicos no novo e
-  inovador artigo da Anthropic.
-url: null
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-code-llm-circuit-tracing.png
+  inovador artigo da Anthropic."
+url: ''
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-code-llm-circuit-tracing.png
 categories:
   - article
 tags:

--- a/content/pt/posts/creating-my-ai-assistant-locally.md
+++ b/content/pt/posts/creating-my-ai-assistant-locally.md
@@ -2,9 +2,8 @@
 date: 2024-03-16T00:00:00.000Z
 draft: false
 title: Criando meu assistente de IA localmente
-description: >-
-  Pela primeira vez, tentei me desconectar do ChatGPT e do Copilot para ver o
-  que eu conseguiria criar.
+description: "Pela primeira vez, tentei me desconectar do ChatGPT e do Copilot para ver o
+  que eu conseguiria criar."
 url: /creating-local-ai/
 featured_image: /images/ollama-privategpt.png
 tags:

--- a/content/pt/posts/experience-with-cursor-and-windsurf.md
+++ b/content/pt/posts/experience-with-cursor-and-windsurf.md
@@ -1,16 +1,13 @@
 ---
 date: 2025-04-13T03:11:32.000Z
 draft: false
-title: >-
-  Do Cursor ao Windsurf ao Zed: Minha Jornada Através de Editores de Código
-  Aprimorados por IA
-description: >-
-  Uma análise pessoal das minhas experiências com Cursor, Windsurf e outros
+title: "Do Cursor ao Windsurf ao Zed: Minha Jornada Através de Editores de Código
+  Aprimorados por IA"
+description: "Uma análise pessoal das minhas experiências com Cursor, Windsurf e outros
   editores de código modernos, incluindo suas capacidades de IA, suporte a
-  extensões e a experiência geral do usuário.
+  extensões e a experiência geral do usuário."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-cursor-windsurf.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-cursor-windsurf.png
 categories:
   - article
 tags:

--- a/content/pt/posts/fix-custom-models-open-webui.md
+++ b/content/pt/posts/fix-custom-models-open-webui.md
@@ -2,10 +2,9 @@
 date: 2025-03-12T01:32:27.000Z
 draft: false
 title: Como corrigir o bug de Modelos Personalizados Ausentes
-description: null
+description: ''
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-custom-model-fix.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-custom-model-fix.png
 categories:
   - article
 tags:

--- a/content/pt/posts/flask-progress-bars-and-beyond.md
+++ b/content/pt/posts/flask-progress-bars-and-beyond.md
@@ -2,12 +2,10 @@
 date: 2025-04-11T14:33:12.000Z
 draft: true
 title: 'Construindo Aplicativos Web Flask Interativos: Barras de Progresso e Além'
-description: >-
-  Um guia prático para implementar barras de progresso, atualizações em tempo
-  real e outras funcionalidades interativas em suas aplicações web Flask.
+description: "Um guia prático para implementar barras de progresso, atualizações em tempo
+  real e outras funcionalidades interativas em suas aplicações web Flask."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-flask-progress-bars.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-flask-progress-bars.png
 categories:
   - tutorial
 tags:

--- a/content/pt/posts/how-to-setup-github-secrets.md
+++ b/content/pt/posts/how-to-setup-github-secrets.md
@@ -1,16 +1,13 @@
 ---
 date: 2025-04-11T19:48:47.000Z
 draft: true
-title: >-
-  Como Configurar e Usar GitHub Secrets com Contêineres e Aplicações Voltadas
-  para a Internet
-description: >-
-  Aprenda a gerenciar com segurança informações confidenciais em seus projetos
+title: "Como Configurar e Usar GitHub Secrets com Contêineres e Aplicações Voltadas
+  para a Internet"
+description: "Aprenda a gerenciar com segurança informações confidenciais em seus projetos
   GitHub usando Segredos e integrá-los com aplicações conteinerizadas e serviços
-  expostos à internet.
+  expostos à internet."
 url: /github-secrets-containers-guide/
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-github-secrets.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-github-secrets.png
 categories:
   - tutorial
 tags:

--- a/content/pt/posts/inpi-automation-roadmap-2025-2029.md
+++ b/content/pt/posts/inpi-automation-roadmap-2025-2029.md
@@ -2,12 +2,10 @@
 date: 2025-03-28T00:51:38.000Z
 draft: false
 title: Roteiro ambicioso de automação do INPI
-description: >-
-  Esta iniciativa visa simplificar o processo de patentes, aprimorar a
-  experiência do usuário e otimizar a eficiência dos examinadores de patentes.
+description: "Esta iniciativa visa simplificar o processo de patentes, aprimorar a
+  experiência do usuário e otimizar a eficiência dos examinadores de patentes."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-inpi-roadmap.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-inpi-roadmap.png
 categories:
   - article
   - video

--- a/content/pt/posts/one-week-review-gitbutler.md
+++ b/content/pt/posts/one-week-review-gitbutler.md
@@ -2,10 +2,9 @@
 date: 2025-04-10T16:36:59.000Z
 draft: false
 title: 'Duas Semanas com GitButler: Simplificando Meu Fluxo de Trabalho Git'
-description: >-
-  Minha experiência usando o GitButler como um substituto para ferramentas
+description: "Minha experiência usando o GitButler como um substituto para ferramentas
   tradicionais de fluxo de trabalho Git, incluindo o que funciona bem e algumas
-  limitações.
+  limitações."
 url: ''
 featured_image: 'https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-gitbutler.png'
 categories:

--- a/content/pt/posts/open-science-collaboration.md
+++ b/content/pt/posts/open-science-collaboration.md
@@ -1,16 +1,13 @@
 ---
 date: 2025-04-11T18:10:30.000Z
 draft: true
-title: >-
-  Como Colaborar Eficazmente em Projetos de Ciência Aberta: Melhores Práticas
-  para Pesquisadores
-description: >-
-  Um guia abrangente para uma colaboração bem-sucedida em iniciativas de ciência
+title: 'Como Colaborar Eficazmente em Projetos de Ciência Aberta: Melhores Práticas
+  para Pesquisadores'
+description: "Um guia abrangente para uma colaboração bem-sucedida em iniciativas de ciência
   aberta, abordando práticas essenciais desde estratégias de comunicação até o
-  gerenciamento de dados e a atribuição de crédito.
+  gerenciamento de dados e a atribuição de crédito."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-open-science-collaboration.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-open-science-collaboration.png
 categories:
   - article
 tags:

--- a/content/pt/posts/python-modules-guide.md
+++ b/content/pt/posts/python-modules-guide.md
@@ -2,14 +2,12 @@
 date: 2025-04-11T14:27:27.000Z
 draft: true
 title: 'Módulos Python: Um Guia para Iniciantes para Organizar Seu Código'
-description: >-
-  Aprenda a usar módulos Python de forma eficaz para organizar seu código,
+description: "Aprenda a usar módulos Python de forma eficaz para organizar seu código,
   importar funcionalidades e construir projetos mais fáceis de manter. Este guia
   abrange desde importações básicas até a criação de seus próprios módulos e
-  pacotes.
+  pacotes."
 url: ''
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-python-modules.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-python-modules.png
 categories:
   - tutorial
 tags:

--- a/content/pt/posts/setup-blob-storage-amazon-s3.md
+++ b/content/pt/posts/setup-blob-storage-amazon-s3.md
@@ -2,13 +2,11 @@
 date: 2025-04-11T18:22:12.000Z
 draft: true
 title: 'Compreendendo o Armazenamento de Blob: Azure, AWS S3, e Alternativas'
-description: >-
-  Um guia completo sobre soluções de armazenamento de blob, incluindo Azure Blob
+description: "Um guia completo sobre soluções de armazenamento de blob, incluindo Azure Blob
   Storage e Amazon S3, sua história, casos de uso, custos e alternativas para
-  armazenamento de objetos eficiente baseado em nuvem.
+  armazenamento de objetos eficiente baseado em nuvem."
 url: /understanding-blob-storage/
-featured_image: >-
-  https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-blob-storage.png
+featured_image: https://lucasaguiarxyzstorage.blob.core.windows.net/images/thumb-blob-storage.png
 categories:
   - article
   - tutorial

--- a/package-lock.json
+++ b/package-lock.json
@@ -1819,9 +1819,9 @@
       }
     },
     "node_modules/fast-uri": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.0.tgz",
-      "integrity": "sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==",
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
+      "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
       "funding": [
         {
           "type": "github",

--- a/scripts/posts-index.json
+++ b/scripts/posts-index.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-05-11T00:51:18.450Z",
+  "last_updated": "2026-05-12T23:58:05.362Z",
   "posts": {
     "10-obsidian-copilot": {
       "slug": "10-obsidian-copilot",
@@ -203,7 +203,7 @@
         "article"
       ],
       "description_en": "The Backlog Combat Plan reduced the overall stock by 80%, but pharmaceutical orders were left out. Understand what changed with Ordinance 110/2025 and what is still pending.",
-      "content_hash_en": "03418325ecf00b8962b9cd8662b6c40349f5073d20e8c388cbc7982260f67b10",
+      "content_hash_en": "78abfeb9fe841593b0767611ede8fdbbc7bafc216b6e9e5a063ab6568e62774e",
       "backlinks": [
         "inpi-automation-roadmap-2025-2029",
         "propostas_pta_patentes_2026",
@@ -373,7 +373,7 @@
         "article"
       ],
       "description_en": "The growing use of Artificial Intelligence in software development is creating systems so complex that, in the future, programmers will act as scientists.",
-      "content_hash_en": "88cbcbe9da4ad96918283d26666bf00b4dfbc7b75ef08fed1e21a7f4926136ba",
+      "content_hash_en": "fa2fcc552486fe07156822d558c7ac3c31517134babbf208b1a5efb774c2e7f4",
       "backlinks": [
         "ai-copy-paste-problem",
         "experience-with-cursor-and-windsurf",
@@ -451,7 +451,7 @@
         "tutorial"
       ],
       "description_en": "Learn how to integrate a custom Beehiiv form into a Hugo website on GitHub Pages, using Cloudflare Workers and monitoring via PostHog.",
-      "content_hash_en": "4ae9f611ae1a7eeecd7d35c656fcadb702953f4e67ee0c734b03fdd9eec1627b",
+      "content_hash_en": "48c4bfb8ae3a4b74ce2831b67661dc677e80b05b88d17f69de133e022caf72d5",
       "backlinks": [
         "oracle_cloud_vps",
         "troubleshooting-proxmox-login-interface",
@@ -575,7 +575,7 @@
         "article"
       ],
       "description_en": "After the STJ denied an extension of time for semaglutide, the discussion about compensation for INPI's delay in pharmaceutical patents moved to the Legislature. What is at stake in Bill No. 5,810/2025.",
-      "content_hash_en": "0ab9ec7143f6fa59b70a81efd307a28503cd040d66d2fce9f9f4d142db6344fd",
+      "content_hash_en": "5fa4d05b69108671559ed4b1638968322e67fae81e45fa36306af62c667d996a",
       "backlinks": [
         "backlog-inpi-patentes-farmaceuticas",
         "inpi-automation-roadmap-2025-2029",
@@ -741,7 +741,7 @@
         "article"
       ],
       "description_en": "Honest perspective from someone who used all three systems for years — why I chose macOS, when Linux is really worth it, and what still bothers me about Windows.",
-      "content_hash_en": "8241e523766205b7813383ddc2528bb6941cbefd8b2ca282b2c4f7134f6b0823",
+      "content_hash_en": "bd7808c241c33f29e3ccde207f9b0b411c82c86153d24944ad7a8a7cb9fbe269",
       "backlinks": [
         "10-years-of-macbook-pro",
         "introduction",
@@ -766,7 +766,7 @@
         "article"
       ],
       "description_en": "An analysis of the article 'When Dawkins met Claude'. Can language models like Claude be conscious, or are we just falling for the Turing Test?",
-      "content_hash_en": "c0dc55f586bc9f21b12cb5dc60847ed9b2bf4a0296ba6b24d531c2b584eb57ee",
+      "content_hash_en": "90f357ae4fa7c4f169405ef3d08ef65b3076032ab0d3ea6092a8899e63afd5eb",
       "backlinks": [
         "anthropic-thinking-process-paper",
         "vibe-coding-pitfalls",
@@ -777,7 +777,7 @@
     },
     "adi-5529-patentes-farmaceuticas": {
       "slug": "adi-5529-patentes-farmaceuticas",
-      "title_en": "ADI 5.529: a decisão do STF que encurtou patentes de medicamentos no Brasil",
+      "title_en": "ADI 5.529: the STF's decision that shortened drug patents in Brazil",
       "title_pt": "ADI 5.529: a decisão do STF que encurtou patentes de medicamentos no Brasil",
       "tags": [
         "patentes",
@@ -790,15 +790,14 @@
       "categories": [
         "article"
       ],
-      "description_en": "Em 2021, o STF derrubou o dispositivo que garantia prazo mínimo de 10 anos de vigência após a concessão de patentes. Entenda o que mudou, quais patentes foram afetadas e o impacto nos preços de medicamentos.",
-      "content_hash_en": null,
-      "content_hash_pt": "e71c128d43a275ef203b9382b6100831ca4a165c8de7ea6deaf18ac31b302b65",
+      "description_en": "In 2021, the STF (Supreme Federal Court) struck down the provision that guaranteed a minimum 10-year validity period after patent grants. Understand what changed, which patents were affected, and the impact on drug prices.",
+      "content_hash_en": "a4177581fb061fbc970e0d6dabb780994007f6151bb274d1f0db9ef863291b70",
       "backlinks": [
-        "propostas_pta_patentes_2026",
+        "propostas_pta_patente_2026",
         "backlog-inpi-patentes-farmaceuticas",
-        "inpi-automation-roadmap-2025-2029"
+        "propostas_pta_patentes_2026"
       ],
-      "backlink_source": "ai",
+      "backlink_source": "file",
       "last_processed": "2026-05-11T00:51:18.450Z"
     }
   }

--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -3,6 +3,7 @@ const fs = require('fs');
 const path = require('path');
 const crypto = require('crypto');
 const matter = require('gray-matter');
+const yaml = require('js-yaml');
 const { GoogleGenerativeAI } = require('@google/generative-ai');
 const { PostHog } = require('posthog-node');
 
@@ -122,7 +123,13 @@ async function translateFile(sourcePath, targetPath, targetLang) {
   data.translation_source_hash = sourceHash;
 
   // Reconstruct file
-  const newRawContent = matter.stringify(translatedBody, data);
+  const newRawContent = matter.stringify(translatedBody, data, {
+    engines: {
+      yaml: {
+        stringify: (obj) => yaml.dump(obj, { lineWidth: -1 })
+      }
+    }
+  });
   
   // Ensure target directory exists
   const targetDir = path.dirname(targetPath);


### PR DESCRIPTION
## Summary
- Add `js-yaml` to `scripts/translate.js` and pass a custom YAML engine with `lineWidth: -1` to `matter.stringify`, so long strings (e.g. `description`, `featured_image`) are serialized as plain inline values instead of folded block scalars (`>-`).
- Manually fix existing affected posts in `content/en/posts/` and `content/pt/posts/` that already had the `>-` formatting.

## Why
`gray-matter`'s default YAML serialization wraps strings longer than ~80 chars into multi-line block scalar form (`>-`). Hugo can misparse these, requiring manual corrections after each automated translation run.

## What a reviewer should know
The fix is a two-line change in `translateFile` (adding the `yaml` require + custom engine option). All other file changes in this PR are one-time cleanups of already-generated files that had the bad formatting.