### PR TITLE
feat: rank homepage by PostHog views + recency, add view counts & most-read rail

### DIFF
--- a/.github/workflows/hugo.yaml
+++ b/.github/workflows/hugo.yaml
@@ -13,6 +13,11 @@ on:
   # Allows you to run this workflow manually from the Actions tab
   workflow_dispatch:
 
+  # Rebuild daily so the popularity ranking / "most read" data refreshes even when
+  # no new content is pushed (view counts change continuously).
+  schedule:
+    - cron: '0 6 * * *'
+
   # Runs after the auto-translation (last step of the content chain) finishes.
   # Bot commits made with GITHUB_TOKEN do not trigger the push event above, so
   # without this the translated/backlinked content is never deployed.
@@ -71,11 +76,22 @@ jobs:
       - name: Install Dart Sass
         run: npm install -g sass
       - name: Install Node.js dependencies
-        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_run' }}
+        if: ${{ github.event_name == 'push' || github.event_name == 'workflow_run' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' }}
         run: |
           if [[ -f package-lock.json || -f npm-shrinkwrap.json ]]; then
             npm ci
-          fi          
+          fi
+      - name: Fetch PostHog view counts
+        # Best-effort: writes data/post_views.json for the popularity ranking.
+        # A PostHog failure must never break the deploy (the script also exits 0
+        # on error and writes an empty file → Hugo falls back to chronological).
+        continue-on-error: true
+        env:
+          POSTHOG_QUERY_API_KEY: ${{ secrets.POSTHOG_QUERY_API_KEY }}
+          POSTHOG_PROJECT_ID: '404499'
+          POSTHOG_API_HOST: 'https://us.posthog.com'
+          VIEWS_WINDOW_DAYS: '0'
+        run: npm run fetch-post-views
       - name: Build with Hugo
         env:
           # For maximum backward compatibility with Hugo modules

--- a/.gitignore
+++ b/.gitignore
@@ -19,5 +19,7 @@ node_modules/*
 .hugo_build.lock
 /public/
 /resources/_gen/
+# View counts gerados no build pelo scripts/fetch-post-views.js (efêmero)
+data/post_views.json
 *.env
 .env

--- a/PROJECT-INIT.md
+++ b/PROJECT-INIT.md
@@ -1,0 +1,114 @@
+# aka CLAUDE.md at July, 9th
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+A bilingual (English/Portuguese) personal blog built with **Hugo** (extended, v0.160.1 in CI) using the `gohugo-theme-ananke` theme, which is a **git submodule** under `themes/`. Deployed to GitHub Pages. The interesting part of this repo is not the Hugo site itself but the Node.js automation layer (`scripts/`) that AI-translates, cross-links, and instruments content, wired together as a chain of GitHub Actions.
+
+## Commands
+
+```bash
+# Local preview (drafts + future-dated posts render because buildFuture=true)
+hugo server -D
+# ...or `npm run dev` to fetch fresh PostHog view counts first, then serve — needed to
+# see the popularity ranking / "Mais lidos" rail locally (data/post_views.json is
+# gitignored and `hugo server` alone never generates it).
+
+# Production build (what CI runs)
+hugo --gc --minify
+
+# Clone/update the theme submodule (required after fresh clone)
+git submodule update --init --recursive
+
+# Content automation (run from repo root; needs DEEPSEEK_API_KEY/GEMINI_API_KEY in .env)
+npm run translate            # sync EN<->PT translations
+npm run suggest-backlinks    # regenerate "Read also"/"Leia também" sections
+npm run backfill-en-slugs -- --dry-run   # one-off slug migration; ALWAYS dry-run first
+npm run fix-links            # rewrite [text](/posts/slug/) -> {{< ref "posts/slug.md" >}}
+npm run annotate             # create PostHog annotation for newly-published posts
+npm run fetch-post-views     # query PostHog pageviews -> data/post_views.json (home ranking)
+npm run release              # release-it: version bump + changelog + GitHub release
+```
+
+There is no test suite, linter, or local dev server script — scripts are run directly with `node`/`npm run` and validated in CI.
+
+## Content model & i18n (read before touching `content/` or `scripts/translate.js`)
+
+- Content lives in `content/en/` and `content/pt/`, selected by `contentDir` in `config.toml`. `DefaultContentLanguage = "en"`. `content/draft/` holds unpublished scratch drafts that Hugo does not build.
+- **The filename is the cross-language translation key.** `content/en/posts/foo.md` and `content/pt/posts/foo.md` are the same post in two languages. This shared filename is what Hugo's `.Translations` and the backlink `relref`s rely on — do **not** rename one side without the other.
+- **Slugs are per-language and translated** (the URL differs between EN/PT), while the filename stays constant. Slug generation is LLM-based with a deterministic slugify fallback (`scripts/slug.js`).
+- **`translation_source_hash`** in a post's front matter is machine-managed by `translate.js` (sha256 of the source file) for update detection. Don't hand-edit it. Editing a source post causes its translation to be regenerated on the next run.
+- **`draft` is a language-neutral field**: publishing one side (`draft: false`) propagates to the other even for posts too old to re-translate. When both sides lack a `translation_source_hash` (a hand-authored pair), **PT is treated as canonical**.
+- Only **recent** posts (≤2 days old by `date`) are (re)translated; older posts only get `draft` synced. Each run is capped (`MAX_TRANSLATIONS = 5`, backlinks `MAX_AI_CALLS = 10`) to bound API cost.
+- Internal links between posts must use the Hugo ref shortcode `{{< ref "posts/slug.md" >}}` (not raw paths) so they survive slug changes; `fix-links.js` migrates old-style links.
+
+## Backlinks system
+
+`scripts/suggest-backlinks.js` maintains `scripts/posts-index.json` as persistent state (titles, hashes, chosen backlinks per slug). It asks the LLM for the 3 most-related posts, then writes a "Read also:" (EN) / "Leia também:" (PT) section into each post. The block-writer is **idempotent**: it strips *all* existing backlink blocks (matching EN/PT header variants, including the "Also read:" the translator sometimes emits) and inserts exactly one, self-healing any duplicated sections.
+
+## Homepage popularity ranking
+
+`scripts/fetch-post-views.js` queries PostHog (**HogQL via the Query API**, `Bearer`
+auth with a **dedicated read-only key `POSTHOG_QUERY_API_KEY`** — scope `query:read`,
+separate from the annotation key — same host/project pattern as `posthog-annotate.js`)
+and writes `data/post_views.json` — a `posts` map (`RelPermalink` → all-time views, bot-filtered)
+plus `trending_7d` (top-10 per language, last 7 days). The file is **ephemeral**:
+generated in the deploy job before `hugo` and **gitignored**, never committed. The
+deploy workflow (`hugo.yaml`) also runs on a **daily `schedule`** so rankings refresh
+without a content push.
+
+`layouts/index.html` ranks posts by a Hacker-News-style score
+`(views+1)/(age_days+2)^gravity` (gravity = `params.rankingGravity`, default 1.2) —
+combining popularity with recency so old high-view posts decay and new posts can
+surface. Per-post front-matter overrides: **`pinned: true`** (force to the top) and
+**`boost: <number>`** (multiply the score). `layouts/partials/most-read.html` renders
+the "Mais lidos / Most read" side rail from `trending_7d` on the `/posts/` archive
+(`_default/list.html`) only — deliberately **not** on the home, whose list is already
+popularity-ranked (it would be redundant). `layouts/partials/func/post-views.html` is a
+value-returning partial (`{{ $v := partial "func/post-views.html" . }}`) that sums a
+page's views across its URL union — reused by the home score loop and by `single.html`,
+which prints the count at the end of each article. **Local caveat:** `hugo server` does
+not run the fetch script, so run `npm run fetch-post-views` first or the counts/rail
+stay hidden (empty data → chronological fallback).
+
+**Pathname matching gotchas (both handled):** (1) English `$pathname` values appear
+both as `/posts/<slug>/` and legacy `/en/posts/<slug>/`; the **script** folds `/en/`
+into `/` and sums. (2) **Slug drift** — the LLM re-slug system (`backfill-en-slugs`,
+slug regeneration) changes a post's slug over time, often *without* writing an alias,
+so most of a post's views sit on its old URL (typically `/posts/<filename>/`, since the
+original slug was filename-derived) while `.RelPermalink` now uses the new slug. So the
+**template** sums views across the *union* of each post's URLs — `.RelPermalink` +
+`/<section>/<.File.ContentBaseName>/` + `.Aliases` — in both `index.html` (score) and
+`most-read.html` (reverse lookup). Without this, the top posts don't match and the rail
+empties. Missing/empty data → template falls back to ~chronological and the rail hides
+itself (build never breaks).
+
+## AI provider layer
+
+`scripts/ai.js` is the shared LLM abstraction. **DeepSeek is primary** (via the OpenAI SDK pointed at `api.deepseek.com`), **Gemini is the automatic fallback**. When adding AI features, follow this primary+fallback pattern rather than replacing the provider. Both `translate.js` and `suggest-backlinks.js` handle 429s with backoff and emit PostHog telemetry/exceptions on failure.
+
+## CI pipeline (`.github/workflows/`) — the non-obvious part
+
+Bot commits made with the default `GITHUB_TOKEN` **do not trigger `push` events**, so the workflows are deliberately chained with `workflow_run` instead of each reacting to `push`:
+
+```
+human push to master (content/**)
+   → Auto Suggest Backlinks (commits backlinks + posts-index.json)
+   → Auto Translate Content (commits translations)   [runs on backlinks completion]
+   → Deploy Hugo site to Pages                        [runs on translate completion]
+```
+
+`hugo.yaml` also explicitly checks out `ref: master` (not the triggering SHA) so the deploy includes the just-committed bot content. If you add a workflow that produces bot commits and expect a rebuild, you must extend this chain — a naive `on: push` will silently never deploy. `posthog-annotate.yaml` runs only on **human** pushes (`github.actor != 'github-actions[bot]'`) to avoid double-annotating when the translation bot recreates a published post in the other language.
+
+## Analytics
+
+PostHog is used both for site analytics and for script/workflow telemetry. **Project ID is 404499 (US region).** The site loads PostHog through a reverse proxy at `t.lucasaguiar.xyz` (`params.posthogHost` in `config.toml`) to dodge ad-blockers. Publish events are recorded as PostHog annotations by `posthog-annotate.js`, which diffs a post's `draft` state across the push range to detect only the false-transition.
+
+## Secrets
+
+Local scripts read `.env` (gitignored) for `DEEPSEEK_API_KEY`, `GEMINI_API_KEY`, `POSTHOG_PERSONAL_API_KEY`, `POSTHOG_QUERY_API_KEY`, `HUGO_POSTHOG_TOKEN`. CI reads the same from repo secrets. The PostHog *personal* API key (annotations, write) is distinct from `POSTHOG_QUERY_API_KEY` (a dedicated read-only key, scope `query:read`, used only by `fetch-post-views.js`) and from the public project key (`phc_...`, ingestion) baked into `config.toml`.
+
+## Conventions
+
+Commits follow Conventional Commits (enforced by commitlint + husky; consumed by release-it for the changelog). Observed prefixes include `feat`, `chore(i18n)`, `chore(seo)`, `content:`, `draft:`, `Publish:`.

--- a/assets/css/main.css
+++ b/assets/css/main.css
@@ -666,6 +666,79 @@ a { color: inherit; text-decoration: none; }
   padding-top: var(--space-3);
 }
 
+/* Recent grid + "Most read" side rail.
+   Default: single column (rail stacks below the posts — safe fallback).
+   Desktop with a rail present: two columns via :has(). Degrades gracefully. */
+.ed-grid-layout {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: var(--space-8);
+  align-items: start;
+}
+@media (min-width: 901px) {
+  .ed-grid-layout:has(.ed-mostread) { grid-template-columns: minmax(0, 1fr) 300px; }
+}
+
+/* "Most read (7 days)" rail */
+.ed-mostread {
+  border-top: 2px solid var(--fg);
+  padding-top: var(--space-4);
+}
+.ed-mostread-head {
+  display: flex;
+  align-items: baseline;
+  justify-content: space-between;
+  gap: var(--space-3);
+  margin-bottom: var(--space-5);
+}
+.ed-mostread-sub {
+  font-family: var(--font-mono);
+  font-size: 10px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+.ed-mostread-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+.ed-mostread-item {
+  display: flex;
+  gap: var(--space-3);
+  padding: var(--space-3) 0;
+  border-bottom: 1px solid var(--border);
+}
+.ed-mostread-item:last-child { border-bottom: none; }
+.ed-mostread-num {
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.08em;
+  color: var(--accent);
+  flex: 0 0 auto;
+  padding-top: 2px;
+}
+.ed-mostread-item a {
+  font-family: var(--font-serif);
+  font-size: 16px;
+  line-height: 1.3;
+  color: var(--fg);
+  transition: color 0.2s;
+}
+.ed-mostread-item a:hover { color: var(--accent); }
+
+/* View count at the end of an article */
+.post-viewcount {
+  margin-top: var(--space-6);
+  padding-top: var(--space-4);
+  border-top: 1px solid var(--border);
+  font-family: var(--font-mono);
+  font-size: 11px;
+  letter-spacing: 0.12em;
+  text-transform: uppercase;
+  color: var(--fg-faint);
+}
+
 /* Pull quote */
 .ed-pull {
   padding: var(--space-9) 0;

--- a/config.toml
+++ b/config.toml
@@ -51,6 +51,9 @@ contactEndpoint = "https://script.google.com/macros/s/AKfycbxzcBA38-8e9imy8LUqOe
 # choose a background color from any on this page: https://tachyons.io/docs/themes/skins/ and preface it with "bg-"
 background_color_class = "bg-black"
 recent_posts_number = 3
+# Decaimento do ranking da home por popularidade: score = (views+1)/(idade_dias+2)^gravity.
+# Maior = decai mais rápido (favorece posts novos); menor = evergreen dura mais.
+rankingGravity = 1.2
 
 [taxonomies]
 category = "categories"

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -50,7 +50,8 @@
       </div>
     </div>
 
-    {{/* Entry list */}}
+    {{/* Entry list + rail "Mais lidos" (só na seção de posts) */}}
+    <div class="ed-grid-layout">
     <div class="blog-list">
       {{ range $allPosts }}
       <article class="blog-entry"
@@ -73,6 +74,8 @@
         </div>
       </article>
       {{ end }}
+    </div>
+    {{ if eq .Section "posts" }}{{ partial "most-read.html" . }}{{ end }}
     </div>
 
     {{/* ── Bottom CTAs ── */}}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -56,6 +56,16 @@
   </div>
   {{ end }}
 
+  {{/* View count (PostHog) — end of article. Hidden when there's no data
+       (e.g. local `hugo server` without running `npm run fetch-post-views`). */}}
+  {{ $views := partial "func/post-views.html" . }}
+  {{ if gt $views 0 }}
+  {{ $sep := cond (eq .Site.Language.Lang "pt") "." "," }}
+  <div class="post-viewcount container">
+    {{ lang.FormatNumberCustom 0 $views "." $sep }} {{ if eq .Site.Language.Lang "pt" }}visualizações{{ else }}views{{ end }}
+  </div>
+  {{ end }}
+
   {{/* Related posts + buy me a coffee */}}
   <div class="post-extras">
     {{- partial "buy-me-coffee.html" . -}}

--- a/layouts/index.html
+++ b/layouts/index.html
@@ -1,6 +1,24 @@
 {{ define "main" }}
 {{ $mainSections := .Site.Params.mainSections | default (slice "posts") }}
-{{ $posts := where .Site.RegularPages "Section" "in" $mainSections }}
+{{ $all := where .Site.RegularPages "Section" "in" $mainSections }}
+
+{{/* ── Ordenação por popularidade: score = (views + 1) / (idade_dias + 2)^gravity ──
+     views vêm de data/post_views.json (por .RelPermalink). `boost` multiplica e
+     `pinned` empurra pro topo (frontmatter). Sem data file → score vira recência
+     pura (≈ cronológico), sem quebra. */}}
+{{ $gravity := .Site.Params.rankingGravity | default 1.2 }}
+{{ $now := now.Unix }}
+{{ $ranked := slice }}
+{{ range $p := $all }}
+  {{/* views somadas pela união de URLs do post (ver func/post-views.html — slug drift) */}}
+  {{ $v := partial "func/post-views.html" $p }}
+  {{ $age := div (sub $now $p.Date.Unix) 86400.0 }}
+  {{ $score := div (add $v 1) (math.Pow (add $age 2.0) $gravity) }}
+  {{ $score = mul $score ($p.Params.boost | default 1) }}
+  {{ if $p.Params.pinned }}{{ $score = add $score 1000000000.0 }}{{ end }}
+  {{ $ranked = $ranked | append (dict "page" $p "score" $score) }}
+{{ end }}
+{{ $posts := apply (sort $ranked "score" "desc") "index" "." "page" }}
 {{ $featured := index $posts 0 }}
 {{ $recent := after 1 (first 4 $posts) }}
 

--- a/layouts/partials/func/post-views.html
+++ b/layouts/partials/func/post-views.html
@@ -1,0 +1,17 @@
+{{- /*
+  Retorna (return) as views totais de um post lidas de data/post_views.json,
+  somando a UNIÃO de URLs que o post já teve — .RelPermalink (atual),
+  /<seção>/<nome-do-arquivo>/ e .Aliases — para sobreviver a slug drift.
+  Retorna 0 se não houver data file. Uso: {{ $v := partial "func/post-views.html" . }}
+  (Partial de valor: não pode emitir texto, por isso o whitespace é todo aparado.)
+*/ -}}
+{{- $p := . -}}
+{{- $total := 0 -}}
+{{- with $p.Site.Data.post_views -}}{{- with .posts -}}
+  {{- $views := . -}}
+  {{- $keys := slice $p.RelPermalink -}}
+  {{- with $p.File -}}{{- $keys = $keys | append (printf "%s%s/" $p.CurrentSection.RelPermalink .ContentBaseName) -}}{{- end -}}
+  {{- range $p.Aliases -}}{{- $keys = $keys | append (cond (strings.HasSuffix . "/") . (printf "%s/" .)) -}}{{- end -}}
+  {{- range $k := (uniq $keys) -}}{{- $total = add $total (index $views $k | default 0) -}}{{- end -}}
+{{- end -}}{{- end -}}
+{{- return $total -}}

--- a/layouts/partials/most-read.html
+++ b/layouts/partials/most-read.html
@@ -1,0 +1,43 @@
+{{/*
+  Seção "Mais lidos (7 dias)" — lê data/post_views.json (trending_7d por idioma),
+  resolve cada pathname para a Page do idioma atual (título/link corretos) e
+  renderiza um <ol>. Não renderiza nada se não houver dados (fallback silencioso).
+  Contexto (.) = a página atual (home).
+*/}}
+{{ with .Site.Data.post_views }}
+  {{ $lang := $.Site.Language.Lang }}
+  {{ $list := index .trending_7d $lang }}
+  {{ with $list }}
+    {{/* lookup pathname -> Page das páginas do idioma atual. Inclui a URL atual
+         (.RelPermalink), a derivada do nome do arquivo e os aliases, para casar com
+         views acumuladas em URLs antigas (slug drift). */}}
+    {{ $lookup := dict }}
+    {{ range $pg := $.Site.RegularPages }}
+      {{ $lookup = merge $lookup (dict $pg.RelPermalink $pg) }}
+      {{ with $pg.File }}{{ $lookup = merge $lookup (dict (printf "%s%s/" $pg.CurrentSection.RelPermalink .ContentBaseName) $pg) }}{{ end }}
+      {{ range $pg.Aliases }}{{ $lookup = merge $lookup (dict (cond (strings.HasSuffix . "/") . (printf "%s/" .)) $pg) }}{{ end }}
+    {{ end }}
+    {{ $items := slice }}
+    {{ range . }}
+      {{ with index $lookup .path }}
+        {{ $items = $items | append . }}
+      {{ end }}
+    {{ end }}
+    {{ with $items }}
+    <aside class="ed-mostread">
+      <div class="ed-mostread-head">
+        <span class="mono-label">{{ if eq $lang "pt" }}Mais lidos{{ else }}Most read{{ end }}</span>
+        <span class="ed-mostread-sub">{{ if eq $lang "pt" }}7 dias{{ else }}7 days{{ end }}</span>
+      </div>
+      <ol class="ed-mostread-list">
+        {{ range $i, $p := . }}
+        <li class="ed-mostread-item">
+          <span class="ed-mostread-num">{{ printf "%02d" (add $i 1) }}</span>
+          <a href="{{ $p.RelPermalink }}">{{ $p.Title }}</a>
+        </li>
+        {{ end }}
+      </ol>
+    </aside>
+    {{ end }}
+  {{ end }}
+{{ end }}

--- a/package.json
+++ b/package.json
@@ -9,7 +9,9 @@
     "backfill-en-slugs": "node scripts/backfill-en-slugs.js",
     "fix-links": "node scripts/fix-links.js",
     "suggest-backlinks": "node scripts/suggest-backlinks.js",
-    "annotate": "node scripts/posthog-annotate.js"
+    "annotate": "node scripts/posthog-annotate.js",
+    "fetch-post-views": "node scripts/fetch-post-views.js",
+    "dev": "npm run fetch-post-views && hugo server -D"
   },
   "repository": {
     "type": "git",

--- a/scripts/fetch-post-views.js
+++ b/scripts/fetch-post-views.js
@@ -1,0 +1,151 @@
+require('dotenv').config();
+const fs = require('fs');
+const path = require('path');
+
+// Coleta contagens de pageview do PostHog (Query API / HogQL) e grava
+// data/post_views.json, consumido pelo template da home para ranquear posts por
+// popularidade (score = views + recência) e para a seção "Mais lidos (7 dias)".
+//
+// RESILIÊNCIA: qualquer falha (chave ausente, erro de rede, resposta vazia) apenas
+// gera um JSON válido porém vazio e sai com código 0 — nunca quebra o build do Hugo.
+// Sem dados, a home cai no fallback cronológico e a lateral some.
+
+// Chave dedicada só de leitura de query (escopo query:read), separada da
+// POSTHOG_PERSONAL_API_KEY usada pelas anotações.
+const QUERY_API_KEY = process.env.POSTHOG_QUERY_API_KEY;
+const PROJECT_ID = process.env.POSTHOG_PROJECT_ID || '404499';
+// Query API do PostHog US (app host), distinto do host de ingestão us.i.posthog.com.
+const API_HOST = process.env.POSTHOG_API_HOST || 'https://us.posthog.com';
+
+// Janela do score. 0 (ou vazio) = "desde sempre" (limitado a ~10 anos por segurança).
+const VIEWS_WINDOW_DAYS = parseInt(process.env.VIEWS_WINDOW_DAYS || '0', 10) || 0;
+const SCORE_INTERVAL_DAYS = VIEWS_WINDOW_DAYS > 0 ? VIEWS_WINDOW_DAYS : 3650;
+const TRENDING_WINDOW_DAYS = parseInt(process.env.TRENDING_WINDOW_DAYS || '7', 10) || 7;
+const TRENDING_LIMIT = parseInt(process.env.TRENDING_LIMIT || '10', 10) || 10;
+
+const OUT_PATH = path.join(__dirname, '..', 'data', 'post_views.json');
+
+// HogQL: pageviews por pathname, excluindo bots. LIKE '%/posts/%' pega EN (/posts/),
+// PT (/pt/posts/) e o legado EN (/en/posts/).
+function pageviewSql(intervalDays, limit) {
+  return `SELECT properties.$pathname AS pathname, count() AS views
+FROM events
+WHERE event = '$pageview'
+  AND timestamp >= now() - INTERVAL ${intervalDays} DAY
+  AND properties.$pathname LIKE '%/posts/%'
+  AND NOT coalesce(properties.$virt_is_bot, false)
+GROUP BY pathname
+ORDER BY views DESC
+LIMIT ${limit}`;
+}
+
+async function runHogQL(sql) {
+  const url = `${API_HOST}/api/projects/${PROJECT_ID}/query/`;
+  const res = await fetch(url, {
+    method: 'POST',
+    headers: {
+      Authorization: `Bearer ${QUERY_API_KEY}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ query: { kind: 'HogQLQuery', query: sql } }),
+  });
+  if (!res.ok) {
+    const detail = await res.text().catch(() => '');
+    throw new Error(`HTTP ${res.status} ${res.statusText} — ${detail.slice(0, 300)}`);
+  }
+  const json = await res.json();
+  // results: [[pathname, views], ...]
+  return Array.isArray(json.results) ? json.results : [];
+}
+
+// Normaliza um pathname do PostHog para casar com o .RelPermalink do Hugo:
+// - garante barra inicial e final;
+// - remove query/hash (defensivo — $pathname já não os tem);
+// - dobra o prefixo legado /en/ no default (/), pois é o mesmo post EN.
+// Retorna null para páginas de índice/paginação, que não são posts.
+function normalizePath(raw) {
+  if (!raw) return null;
+  let p = String(raw).split('#')[0].split('?')[0].trim();
+  if (!p.startsWith('/')) p = '/' + p;
+  if (!p.endsWith('/')) p = p + '/';
+  if (p.startsWith('/en/')) p = p.slice(3); // '/en/posts/x/' -> '/posts/x/'
+  if (p.includes('/page/')) return null; // paginação
+  // páginas de seção (listagem), não posts individuais
+  if (p === '/posts/' || p === '/pt/posts/') return null;
+  // precisa ter um slug depois de posts/
+  if (!/\/posts\/[^/]+\//.test(p)) return null;
+  return p;
+}
+
+function langOf(normalizedPath) {
+  return normalizedPath.startsWith('/pt/') ? 'pt' : 'en';
+}
+
+// Soma views por pathname normalizado (funde /en/ com /).
+function foldRows(rows) {
+  const map = new Map();
+  for (const row of rows) {
+    const p = normalizePath(row[0]);
+    if (!p) continue;
+    const views = Number(row[1]) || 0;
+    map.set(p, (map.get(p) || 0) + views);
+  }
+  return map;
+}
+
+function emptyPayload() {
+  return {
+    generated_at: new Date().toISOString(),
+    window_days: VIEWS_WINDOW_DAYS,
+    posts: {},
+    trending_7d: { en: [], pt: [] },
+  };
+}
+
+function writePayload(payload) {
+  fs.mkdirSync(path.dirname(OUT_PATH), { recursive: true });
+  fs.writeFileSync(OUT_PATH, JSON.stringify(payload, null, 2) + '\n');
+}
+
+async function main() {
+  if (!QUERY_API_KEY) {
+    console.warn('[fetch-post-views] POSTHOG_QUERY_API_KEY ausente — gravando post_views.json vazio (fallback cronológico).');
+    writePayload(emptyPayload());
+    return;
+  }
+
+  // Score (all-time): mapa pathname -> views totais.
+  const scoreMap = foldRows(await runHogQL(pageviewSql(SCORE_INTERVAL_DAYS, 1000)));
+
+  // Trending (7 dias): top N por idioma.
+  const trendingMap = foldRows(await runHogQL(pageviewSql(TRENDING_WINDOW_DAYS, 300)));
+  const trending = { en: [], pt: [] };
+  const ordered = [...trendingMap.entries()].sort((a, b) => b[1] - a[1]);
+  for (const [p, views] of ordered) {
+    const lang = langOf(p);
+    if (trending[lang].length < TRENDING_LIMIT) trending[lang].push({ path: p, views });
+  }
+
+  const payload = {
+    generated_at: new Date().toISOString(),
+    window_days: VIEWS_WINDOW_DAYS,
+    posts: Object.fromEntries(scoreMap),
+    trending_7d: trending,
+  };
+  writePayload(payload);
+  console.log(
+    `[fetch-post-views] OK — ${scoreMap.size} posts (score), ` +
+      `trending 7d: ${trending.en.length} EN / ${trending.pt.length} PT → ${OUT_PATH}`
+  );
+}
+
+main().catch((err) => {
+  // Nunca derrubar o build: loga e grava JSON vazio.
+  console.warn(`[fetch-post-views] falha ao consultar o PostHog: ${err.message}`);
+  try {
+    writePayload(emptyPayload());
+  } catch (e) {
+    console.warn(`[fetch-post-views] não foi possível gravar o arquivo vazio: ${e.message}`);
+  }
+  process.exit(0);
+});


### PR DESCRIPTION
## What

Rank the homepage by real popularity (PostHog pageviews) combined with recency, add a per-article view count, and a "Mais lidos / Most read (7 days)" rail on the blog archives.

## Why

The homepage listed posts purely by date. This surfaces the most-read / most-relevant essays while still giving new posts room to climb (recency decay), and exposes trending posts on the `/posts` archive.

## How it works

- **Collection** — `scripts/fetch-post-views.js` runs HogQL via the PostHog Query API (dedicated `POSTHOG_QUERY_API_KEY`, scope `query:read`) and writes `data/post_views.json` (**ephemeral, gitignored**): all-time views per post + a 7-day trending list per language. Folds legacy `/en/` pathnames into `/` and filters bots. **Resilient**: any failure → empty file + exit 0, so the build never breaks.
- **Home ranking** — score `(views + 1) / (age_days + 2) ^ gravity` (`params.rankingGravity`, default `1.2`). Per-post front-matter overrides: `pinned: true` (force to top) and `boost: <n>` (multiply score).
- **Slug drift** — `layouts/partials/func/post-views.html` sums each post's views across the *union* of its URLs (`.RelPermalink` + filename-derived path + `.Aliases`), so views that accumulated on old slugs / legacy prefixes aren't lost. Reused by `single.html` to print the count at the end of each article.
- **Most-read rail** — on `/posts` and `/pt/posts` (`_default/list.html`) only; **not** the home, which is already popularity-ranked (would be redundant).
- **CI** — best-effort fetch step before the Hugo build + a daily `schedule` so rankings refresh without a content push.

## Testing (local, against real project data)

- EN home featured = highest-scoring post; high-view posts recovered via the filename-path union (e.g. `migrate-proxmox` = 837 views that were split across `/en/…` and the old slug).
- View count renders at the end of EN (`837 views`) and PT (`2 visualizações`) posts, with localized number formatting.
- Rail shows 10 items on both `/posts` and `/pt/posts`; hides itself with no data (chronological fallback); Hugo build is clean.

## Deploy notes

- Requires the `POSTHOG_QUERY_API_KEY` secret (scope `query:read`) in GitHub Actions — **configured**.
- `data/post_views.json` is gitignored/ephemeral, regenerated each deploy + daily cron.
- Local preview: `npm run dev` (fetches views, then `hugo server -D`) — plain `hugo server` won't show the ranking since it doesn't generate the data file.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
