### PR TITLE
fix(i18n): repair alias template to unblock /pt build

### DIFF
--- a/layouts/_default/alias.html
+++ b/layouts/_default/alias.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="{{ .Site.Language.Lang }}">
+<html lang="{{ site.Language.Lang }}">
   <head>
     <title>{{ .Permalink }}</title>
     <link rel="canonical" href="{{ .Permalink }}">


### PR DESCRIPTION
## What

Change `layouts/_default/alias.html` to use the global `site.Language.Lang` instead of `.Site.Language.Lang`.

## Why

Hugo 0.152 no longer exposes a usable `.Site` inside the alias render context. `{{ .Site.Language.Lang }}` therefore threw:

```
nil pointer dereference ... executing "alias.html" at <.Site.Language.Lang>
```

This aborted the **entire build**. Because Hugo writes the default language (`en`, at the root) first and crashed on an alias before writing `/pt/`, the whole `/pt/` tree — including `/pt/posts/` — was never generated. As a result, the "Todos os ensaios" back link on Portuguese posts pointed at `/pt/posts/`, which 404'd.

The build-breaking aliases come from `aliases:` in the section front matter (e.g. `/pt/posts/page/2/` in `content/pt/posts/_index.md`).

Note: the `single.html` back-link snippet was **not** the cause — it already generated the correct `href="/pt/posts/"`; the target simply didn't exist because the build failed.

## Verification

Local `hugo` build:

| Before | After |
|--------|-------|
| build fails (nil pointer) | build succeeds — 573 pt / 625 en pages, 51 + 2 aliases |
| `/pt/posts/index.html` missing | `/pt/posts/index.html` generated (169k) |
| aliases don't render | `lang="pt"` on PT aliases, `lang="en"` on EN aliases |

## Reviewer notes

- One-line template change, no content changes.
- Unrelated pre-existing `WARN REF_NOT_FOUND` warnings (EN posts with `relref` to missing PT slugs) remain — non-fatal, out of scope for this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)