### PR TITLE
fix(i18n): freeze translated slugs, preserve old URLs as aliases

### DIFF
--- a/content/en/posts/acao-infracao-patente-brasil-guia-completo.md
+++ b/content/en/posts/acao-infracao-patente-brasil-guia-completo.md
@@ -113,11 +113,11 @@ Strategic point: crimes against patents are **private criminal action (criminal 
 
 The final message is symmetrical: for the holder, a patent only has value if there is an enforcement plan; for those who produce with third-party technology, the freedom-to-operate audit (*freedom to operate*) is cheaper than any judicial defense. On both sides, knowledge of art. 42 to art. 225 of the LPI is the first asset.
 
-Also read:
+Read also:
 
-- [How to File a Patent with the INPI: Complete Step-by-Step Guide [2026]]({{< relref "posts/guia-deposito-patente-inpi-2026/" >}})
-- [How to File a Patent with the INPI: Complete Step-by-Step Guide [2026]]({{< relref "posts/guia-deposito-patente-inpi-2026/" >}})
-- [How to File a Patent with the INPI: Complete Step-by-Step Guide [2026]]({{< relref "posts/guia-deposito-patente-inpi-2026/" >}})
+- [How to File a Patent at INPI: Complete Step-by-Step Guide [2026]]({{< relref "posts/guia-deposito-patente-inpi-2026/" >}})
+- [How to File a Patent at INPI: Complete Step-by-Step Guide [2026]]({{< relref "posts/guia-deposito-patente-inpi-2026/" >}})
+- [How to File a Patent at INPI: Complete Step-by-Step Guide [2026]]({{< relref "posts/guia-deposito-patente-inpi-2026/" >}})
 
 ---
 

--- a/content/pt/posts/supply-chain-security-malicious-packages-guide-2026.md
+++ b/content/pt/posts/supply-chain-security-malicious-packages-guide-2026.md
@@ -100,8 +100,8 @@ O incidente do arrayref mostra que até mesmo um crate conhecido com centenas de
 
 Leia também:
 
-- [Como Reduzir CVEs nas Suas Imagens Docker: Guia de Segurança de Containers [2026]]({{< relref "posts/reducing-cves-container-images-guide-2026/" >}})
-- [Como Configurar e Usar Segredos do GitHub com Containers e Aplicações Expostas à Internet]({{< relref "posts/how-to-setup-github-secrets/" >}})
+- [Como Reduzir CVEs em Suas Imagens Docker: Guia de Segurança de Contêineres [2026]]({{< relref "posts/reducing-cves-container-images-guide-2026/" >}})
+- [Como Configurar e Usar GitHub Secrets com Contêineres e Aplicações Voltadas para a Internet]({{< relref "posts/how-to-setup-github-secrets/" >}})
 - [GitLost [2026]: Como a Injeção de Prompt no Agente de IA do GitHub Vaza Repositórios Privados]({{< relref "posts/gitlost-github-agentic-workflows-prompt-injection-2026/" >}})
 
 ---

--- a/scripts/posts-index.json
+++ b/scripts/posts-index.json
@@ -1,5 +1,5 @@
 {
-  "last_updated": "2026-08-20T18:07:40.017Z",
+  "last_updated": "2026-08-20T18:44:02.365Z",
   "posts": {
     "10-obsidian-copilot": {
       "slug": "10-obsidian-copilot",
@@ -4253,8 +4253,8 @@
       "categories": [
         "article"
       ],
-      "description_en": "Complete guide to patent infringement action in Brazil: rights of the holder (art. 42 of the LPI), legal limits, provisional remedies, technical expert examination, damages (art. 210), and nullity as defense.",
-      "content_hash_en": "597b95670414dec6e39d04dce6475a6119f789ce7580d7bb8bf908809b6d1566",
+      "description_en": "Complete guide to patent infringement action in Brazil: rights of the holder (art. 42 of the LPI), legal limits, preliminary injunction, technical expert examination, damages (art. 210), and nullity as a defense.",
+      "content_hash_en": "91600b6a095de5fa1beee599a8237a8b8175f3d7563c6f96755ebd9803efad48",
       "backlinks": [
         "guia-deposito-patente-inpi-2026",
         "guia-deposito-patente-inpi-2026",
@@ -4266,7 +4266,7 @@
     "supply-chain-security-malicious-packages-guide-2026": {
       "slug": "supply-chain-security-malicious-packages-guide-2026",
       "title_en": "How to Protect Against Malicious Packages: npm, PyPI, and Cargo Supply Chain Security [2026]",
-      "title_pt": "How to Protect Against Malicious Packages: npm, PyPI, and Cargo Supply Chain Security [2026]",
+      "title_pt": "Como Proteger contra Pacotes Maliciosos: Segurança da Cadeia de Suprimentos para npm, PyPI e Cargo [2026]",
       "tags": [
         "supply-chain",
         "security",
@@ -4279,13 +4279,13 @@
         "article"
       ],
       "description_en": "Complete guide to defending against malicious packages in npm, PyPI and crates.io: typosquatting, account takeover, build-time payloads, audit tools and lockfile hygiene. Includes the August 2026 arrayref incident.",
-      "content_hash_en": "08eb9de1e3a1a9173ee6e7d142eb9a20ab296752802b901baad99ced973e635a",
+      "content_hash_en": "15fc5c37b589275814c3930fdca50014c1478272b9ce669ea23a2c270280b95d",
       "backlinks": [
         "reducing-cves-container-images-guide-2026",
         "how-to-setup-github-secrets",
         "gitlost-github-agentic-workflows-prompt-injection-2026"
       ],
-      "backlink_source": "ai",
+      "backlink_source": "file",
       "last_processed": "2026-08-20T18:07:40.017Z"
     }
   }

--- a/scripts/translate.js
+++ b/scripts/translate.js
@@ -193,6 +193,69 @@ function collectExistingSlugs(dir, excludePath) {
   return set;
 }
 
+// Normalise a front matter `aliases` value (string | array | undefined) into a
+// plain array so it can be merged/extended without special-casing.
+function toAliasArray(aliases) {
+  if (!aliases) return [];
+  return Array.isArray(aliases) ? aliases.slice() : [aliases];
+}
+
+// URL base for the `posts` section in the target file's language, matching how
+// Hugo actually serves it: EN (the default language) at the site root
+// ('/posts/'), PT under its subdir ('/pt/posts/'). Hugo writes aliases verbatim
+// (no automatic language prefixing — verified against the built site), so the
+// alias path must already carry the correct prefix.
+function sectionUrlBase(targetPath) {
+  const abs = path.resolve(targetPath);
+  const isPt = abs.startsWith(path.resolve(PT_DIR) + path.sep);
+  const langDir = isPt ? PT_DIR : EN_DIR;
+  const relDir = path.dirname(path.relative(langDir, targetPath)); // 'posts' | '.'
+  const parts = [isPt ? 'pt' : null, relDir === '.' ? null : relDir].filter(Boolean);
+  return `/${parts.join('/')}/`.replace(/\/{2,}/g, '/');
+}
+
+// Pure decision for a translated post's URL identity, kept LLM-free so it can be
+// unit-tested. Returns the { slug?, url?, aliases? } to apply to the target front
+// matter. Inputs:
+//   targetData    – the existing translation's front matter, or null on the first
+//                   translation.
+//   targetBase    – the target filename without extension (the fallback slug).
+//   urlBase       – section URL base incl. language prefix ('/posts/' | '/pt/posts/').
+//   generatedSlug – a freshly minted native-language slug, used only when there is
+//                   no existing translation.
+//   forceSlug     – an intentional reslug that overrides the freeze (e.g. a future
+//                   --reslug mode); the previous URL is kept as an alias.
+//
+// Rules: an existing translation keeps its current URL — freeze the slug, or honor
+// a pinned `url:` — so routine re-translations never churn the address (and never
+// orphan the post's accumulated views). Only a first translation takes the
+// generated slug. Whenever the effective URL differs from what the target was
+// already published under, the old URL is retained as an alias (a Hugo redirect),
+// and any aliases the target already had are carried forward — never the source's,
+// which belong to the other language.
+function resolveTargetUrl({ targetData, targetBase, urlBase, generatedSlug, forceSlug }) {
+  const aliasSet = new Set(targetData ? toAliasArray(targetData.aliases) : []);
+  const oldSlug = targetData ? (targetData.slug || targetBase) : null;
+  const oldUrl = targetData && !targetData.url && oldSlug ? `${urlBase}${oldSlug}/` : null;
+
+  const out = {};
+  if (forceSlug) {
+    out.slug = forceSlug;                     // intentional reslug (overrides freeze)
+  } else if (targetData && targetData.url) {
+    out.url = targetData.url;                 // explicit permalink — respect verbatim
+  } else if (targetData) {
+    if (targetData.slug) out.slug = targetData.slug; // freeze existing slug
+    // else: filename-based URL, leave slug unset to keep it that way
+  } else if (generatedSlug) {
+    out.slug = generatedSlug;                 // first translation → native slug
+  }
+
+  const newSlug = out.url ? null : (out.slug || targetBase);
+  if (oldUrl && newSlug && `${urlBase}${newSlug}/` !== oldUrl) aliasSet.add(oldUrl);
+  if (aliasSet.size) out.aliases = [...aliasSet];
+  return out;
+}
+
 async function translateFile(sourcePath, targetPath, targetLang) {
   console.log(`Translating: ${sourcePath} -> ${targetLang}`);
   
@@ -212,20 +275,39 @@ async function translateFile(sourcePath, targetPath, targetLang) {
     data.description = stripHeadingPrefix(await translateContent(data.description, targetLang));
   }
 
-  // Generate a slug in the target language so the translated post gets a
-  // native-language URL, even though it keeps the source's filename (the shared
-  // filename stays the cross-language translation key that Hugo's .Translations
-  // and the backlinks relrefs rely on). Overwrites any slug inherited from the
-  // source, which would otherwise be in the source language.
-  if (data.title) {
+  // ── Slug + aliases: per-language URLs that stay STABLE across re-translations ──
+  // The translated post gets a native-language slug (EN slug for EN, PT for PT)
+  // so its URL reads naturally, while keeping the source's filename (the shared
+  // filename is the cross-language translation key that Hugo's .Translations and
+  // the backlinks relrefs rely on).
+  //
+  // generateSlug() is LLM-backed and non-deterministic, so regenerating on every
+  // update would churn the URL and orphan the post's accumulated PostHog views
+  // (the home ranking sums views by URL — see func/post-views.html). So we mint a
+  // slug only on the FIRST translation; on re-translation we reuse the target's
+  // existing slug. If a slug ever does change, the old URL is preserved as an
+  // alias (a Hugo redirect) so no inbound link or view count is lost.
+  const targetData = fs.existsSync(targetPath)
+    ? (() => { try { return matter(fs.readFileSync(targetPath, 'utf8')).data; } catch { return null; } })()
+    : null;
+  const targetBase = path.basename(targetPath).replace(/\.md$/, '');
+  const urlBase = sectionUrlBase(targetPath); // '/posts/' (EN) | '/pt/posts/' (PT)
+
+  // Mint a native-language slug only when there is no existing translation to
+  // keep stable — this is the sole place the (non-deterministic) LLM slug runs.
+  let generatedSlug = null;
+  if (!targetData && data.title) {
     const year = data.date ? new Date(data.date).getFullYear() : new Date().getFullYear();
     const existingSlugs = collectExistingSlugs(path.dirname(targetPath), targetPath);
-    data.slug = ensureUniqueSlug(await generateSlug(data.title, targetLang), existingSlugs, year);
+    generatedSlug = ensureUniqueSlug(await generateSlug(data.title, targetLang), existingSlugs, year);
   }
 
-  // Aliases inherited from the source point at the source language's old URLs
-  // and would be wrong for a post with a different slug — drop them on the target.
-  if ('aliases' in data) delete data.aliases;
+  // Clear any source-derived url/slug/aliases, then apply the resolved identity.
+  delete data.url; delete data.slug; delete data.aliases;
+  const resolved = resolveTargetUrl({ targetData, targetBase, urlBase, generatedSlug });
+  if (resolved.url) data.url = resolved.url;
+  if (resolved.slug) data.slug = resolved.slug;
+  if (resolved.aliases) data.aliases = resolved.aliases;
 
   // Translate Body
   let translatedBody = body;
@@ -422,4 +504,4 @@ if (require.main === module) {
   });
 }
 
-module.exports = { syncNeutralFrontMatter, stringifyPost, NEUTRAL_FM_FIELDS };
+module.exports = { syncNeutralFrontMatter, stringifyPost, NEUTRAL_FM_FIELDS, toAliasArray, sectionUrlBase, resolveTargetUrl };


### PR DESCRIPTION
## What

`scripts/translate.js` no longer regenerates a translated post's URL slug on every re-translation. It now **mints a native-language slug only on the first translation** and **freezes it** thereafter (or honors a pinned `url:`).

## Why

`generateSlug()` is LLM-backed and **non-deterministic**. On the update path, `translateFile()` re-ran it on every re-translation, so a routine content edit (within the 2-day re-translation window) could silently change a translated post's URL. That:

- **orphans the post's PostHog view count** — the home popularity ranking sums views *by URL* (`layouts/partials/func/post-views.html`), so a moved URL drops the post out of the ranking; and
- **404s inbound links** to the old URL (no redirect was left behind).

## How

- The URL decision is extracted into a **pure, LLM-free, unit-tested** `resolveTargetUrl({ targetData, targetBase, urlBase, generatedSlug, forceSlug })`.
- Existing translation → **freeze** the current slug (no LLM call); brand-new translation → generated native slug.
- **Alias safety net:** if the effective URL ever changes (e.g. a future `--reslug` via `forceSlug`), the old URL is kept as a Hugo alias; the post's own existing aliases are carried forward, while source-language aliases are dropped.
- Alias paths carry the correct language prefix — `/posts/` for EN (default lang, served at root), `/pt/posts/` for PT — verified against the built `public/` (Hugo writes aliases verbatim, no auto prefixing).

## Reviewer notes

- **Behavior change:** translated slugs no longer auto-update when a source title changes. This is intentional (URL stability / SEO); the `forceSlug` seam is there for an explicit future reslug mode.
- Only governs the **derived translation** side; renaming the canonical PT source slug by hand still needs a manual alias.
- Mirrors the alias-preservation pattern already proven in `scripts/backfill-en-slugs.js`.
- Verified with 12 scenario tests over `resolveTargetUrl` (first EN/PT translation, freeze, filename-based, pinned url, alias carry-forward/normalisation/dedup, forced reslug) — all green. No repo test runner exists yet, so the tests are not committed; happy to add `npm test` if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)